### PR TITLE
refactor: E13-01 審査中画面の内部実装を改善 #60

### DIFF
--- a/frontend/src/features/judging/__tests__/JudgingScreen.refactor.test.tsx
+++ b/frontend/src/features/judging/__tests__/JudgingScreen.refactor.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import App from '../../../App'
+import { api } from '../../../shared/services/api'
+
+vi.mock('@tanstack/react-query-devtools', () => ({
+  ReactQueryDevtools: () => <div data-testid="react-query-devtools" />,
+}))
+
+describe('E13-01 REFACTOR: JudgingScreen edge cases', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  async function submitValidPost() {
+    fireEvent.change(screen.getByLabelText('ニックネーム'), { target: { value: '太郎' } })
+    fireEvent.change(screen.getByLabelText('あるある本文'), {
+      target: { value: 'スヌーズ押して二度寝' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '投稿する' }))
+
+    await waitFor(() => {
+      expect(api.posts.create).toHaveBeenCalledTimes(1)
+    })
+  }
+
+  it('投稿詳細取得成功時にフォールバック本文から取得本文へ更新する', async () => {
+    vi.spyOn(api.posts, 'create').mockResolvedValue({ id: 'judging-refactor-1', status: 'judging' })
+    vi.spyOn(api.posts, 'get').mockResolvedValue({
+      id: 'judging-refactor-1',
+      nickname: '太郎',
+      body: '更新後の本文',
+      status: 'judging',
+      created_at: '2026-02-16T00:00:00Z',
+      judgments: [],
+    })
+
+    render(<App />)
+    await submitValidPost()
+
+    expect(await screen.findByText('更新後の本文')).toBeInTheDocument()
+  })
+
+  it('投稿詳細のnickname/bodyが空文字なら既定フォールバックを維持する', async () => {
+    vi.spyOn(api.posts, 'create').mockResolvedValue({ id: 'judging-refactor-2', status: 'judging' })
+    vi.spyOn(api.posts, 'get').mockResolvedValue({
+      id: 'judging-refactor-2',
+      nickname: '',
+      body: '',
+      status: 'judging',
+      created_at: '2026-02-16T00:00:00Z',
+      judgments: [],
+    })
+
+    render(<App />)
+    await submitValidPost()
+
+    expect(await screen.findByText('名無し')).toBeInTheDocument()
+    expect(screen.getByText('投稿内容を読み込み中です')).toBeInTheDocument()
+  })
+
+  it('投稿詳細取得失敗時も審査中画面の表示を継続する', async () => {
+    vi.spyOn(api.posts, 'create').mockResolvedValue({ id: 'judging-refactor-3', status: 'judging' })
+    vi.spyOn(api.posts, 'get').mockRejectedValue(new Error('network error'))
+
+    render(<App />)
+    await submitValidPost()
+
+    await waitFor(() => {
+      expect(api.posts.get).toHaveBeenCalledTimes(1)
+    })
+
+    expect(await screen.findByTestId('judging-screen')).toBeInTheDocument()
+    expect(screen.getByText('投稿内容を読み込み中です')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## 📝 概要
E13-01（審査中画面 UI）のRefactorフェーズとして、挙動を変えずに `App.tsx` の可読性・保守性を改善しました。

## 📸 スクリーンショット
- [ ] ここにスクリーンショットを貼り付け
- [ ] ここにスクリーンショットを貼り付け

## ✨ 変更内容
- `frontend/src/App.tsx`
  - 審査中画面初期化処理を `startJudgingScreen` に分離
  - 投稿詳細取得処理を `fetchJudgingPostDetail` に分離（IIFE解消）
  - `名無し` / ひろゆき表示index / 口癖文言を定数化してマジックナンバーを削減
  - 複雑な分岐に日本語コメントを追加
- `frontend/src/features/judging/__tests__/JudgingScreen.refactor.test.tsx` を新規追加
  - 投稿詳細取得成功時にフォールバック本文から更新されること
  - nickname/body が空文字のとき既定フォールバックを維持すること
  - 投稿詳細取得失敗時でも審査中画面表示を継続すること

## ✅ テスト
- `cd frontend && npx vitest run src/features/judging/__tests__/JudgingScreen.refactor.test.tsx`
  - 3 tests passed

## 🔍 影響範囲
- フロントエンド（審査中画面表示ロジック）の内部実装のみ
- API仕様・レスポンス仕様の変更なし

## 📌 関連Issue
- #60
