### PR TITLE
fix: E19-01 フロントデプロイ安定化とDynamoDB整合修正 #80

### DIFF
--- a/backend/config/initializers/dynamoid.rb
+++ b/backend/config/initializers/dynamoid.rb
@@ -30,8 +30,10 @@ Rails.application.config.after_initialize do
     else
       config.endpoint = nil # AWS DynamoDB
       config.region = ENV['AWS_REGION'] || 'ap-northeast-1'
-      config.access_key = ENV.fetch('AWS_ACCESS_KEY_ID', nil)
-      config.secret_key = ENV.fetch('AWS_SECRET_ACCESS_KEY', nil)
+      # Lambda実行ロールの一時認証情報（session token含む）を利用する。
+      # access_key/secret_key を個別指定すると session token が欠け、認証エラーを起こしうる。
+      config.access_key = nil
+      config.secret_key = nil
       config.namespace = nil # 本番ではネームスペースなし
     end
   end

--- a/backend/terraform/dynamodb.tf
+++ b/backend/terraform/dynamodb.tf
@@ -29,9 +29,9 @@ resource "aws_dynamodb_table" "posts" {
   }
 
   # Global Secondary Index: RankingIndex
-  # Dynamoidの :ranking_index に対応（kebab-caseで統一）
+  # Dynamoidの :ranking_index に対応（実テーブル名もsnake_caseで統一）
   global_secondary_index {
-    name            = "ranking-index"
+    name            = "ranking_index"
     hash_key        = "status"
     range_key       = "score_key"
     projection_type = "ALL"


### PR DESCRIPTION
## 概要
E19-01 のフロント自動デプロイ改善・CI安定化・DynamoDB連携不整合の修正を、直近マージコミット（`77d256cb` / PR #79）以降の差分としてまとめました。

## スクリーンショット
- ここに画像をドラッグ&ドロップして貼り付けてください

## 変更内容
### 1. フロントデプロイ/環境変数まわりの改善
- `deploy-frontend.yml` の事前検証を強化し、必要値の不足や参照ミスを早期検知できるよう修正
- フロント側 API 接続設定を必須化し、設定漏れ時の不正なデプロイを防止
- デプロイ変数参照にフォールバックを追加し、運用時の設定揺れに対して耐性を向上

### 2. CIテスト基盤の安定化
- workflow テストの存在判定・順序検証を厳密化
- 冗長な存在確認を整理し、テストの意図を明確化
- E2E 実行の不安定要因を減らし、再現性を改善

### 3. DynamoDB整合性の修正（今回の最終調整）
- 本番の Dynamoid 設定で `access_key/secret_key` の固定指定を廃止し、実行ロール認証を利用するよう修正
- Terraform の posts GSI 名を `ranking-index` から `ranking_index` に修正し、モデル定義（`:ranking_index`）と整合

## 変更ファイル（代表）
- `.github/workflows/deploy-frontend.yml`
- `frontend/src/shared/services/api.ts`
- `frontend/tests/workflow/*`
- `backend/config/initializers/dynamoid.rb`
- `backend/terraform/dynamodb.tf`

## 動作確認
- `bundle exec rubocop config/initializers/dynamoid.rb` : ✅ Passed
- `bundle exec rspec spec/models/post_spec.rb` : ⚠️ 実行環境で DynamoDB Local 未起動のため失敗（接続前提エラー）

## 影響範囲
- フロントの自動デプロイワークフロー
- フロントの API 接続設定
- 本番 DynamoDB 認証およびランキング GSI 参照

## 補足
- 原因対応に不要な差分は整理済みで、最小限の機能変更に最適化しています。
