### PR TITLE
fix: E19-01 Backend Deployロール解決を修正 #80

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   AWS_REGION: ap-northeast-1
-  AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN || secrets.AWS_ROLE_ARN_FRONTEND_DEPLOY || vars.AWS_ROLE_ARN_FRONTEND_DEPLOY }}
+  AWS_ROLE_ARN_BACKEND_DEPLOY: ${{ secrets.AWS_ROLE_ARN_BACKEND_DEPLOY || vars.AWS_ROLE_ARN_BACKEND_DEPLOY || secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
   ECR_REPOSITORY: aruaruarena-backend
   LAMBDA_FUNCTION_NAME: aruaruarena-rails
 
@@ -38,7 +38,7 @@ jobs:
         run: |
           missing_vars=()
 
-          [ -n "${AWS_ROLE_ARN:-}" ] || missing_vars+=("AWS_ROLE_ARN")
+          [ -n "${AWS_ROLE_ARN_BACKEND_DEPLOY:-}" ] || missing_vars+=("AWS_ROLE_ARN_BACKEND_DEPLOY")
           [ -n "${AWS_REGION:-}" ] || missing_vars+=("AWS_REGION")
 
           if [ ${#missing_vars[@]} -gt 0 ]; then
@@ -49,7 +49,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN_BACKEND_DEPLOY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
## 概要
Backend Deploy が frontend 用ロールで実行され、ECR権限不足で失敗していた問題を修正します。

## 原因
- `AWS_ROLE_ARN` の解決が frontend 用ロールへフォールバックしていた
- そのため `github-actions-frontend-deploy-role` が使われ、`ecr:GetAuthorizationToken` が拒否された

## 変更
- `AWS_ROLE_ARN_BACKEND_DEPLOY` を導入
- 解決順を backend 用に固定
  - `secrets.AWS_ROLE_ARN_BACKEND_DEPLOY`
  - `vars.AWS_ROLE_ARN_BACKEND_DEPLOY`
  - `secrets.AWS_ROLE_ARN`
  - `vars.AWS_ROLE_ARN`
- `Validate deploy variables` を `AWS_ROLE_ARN_BACKEND_DEPLOY` 検証へ変更
- `configure-aws-credentials` が `AWS_ROLE_ARN_BACKEND_DEPLOY` を使用
