### PR TITLE
fix: E19-01 Geminiモデルを2.5-flashへ更新 #80

### DIFF
--- a/backend/app/adapters/gemini_adapter.rb
+++ b/backend/app/adapters/gemini_adapter.rb
@@ -13,8 +13,8 @@ class GeminiAdapter < BaseAiAdapter
   # Gemini APIのベースURL
   BASE_URL = 'https://generativelanguage.googleapis.com'
 
-  # Gemini 2.0 Flash Experimentalモデル
-  MODEL_NAME = 'gemini-2.0-flash-exp'
+  # Gemini 2.5 Flashモデル
+  MODEL_NAME = 'gemini-2.5-flash'
 
   # APIバージョン
   API_VERSION = 'v1beta'


### PR DESCRIPTION
## 概要
Gemini審査で `model not found` が発生していたため、モデル名を有効な `gemini-2.5-flash` に更新します。

## 原因
- 既存設定 `gemini-2.0-flash-exp` が v1beta generateContent で 404 を返していた

## 変更内容
- `GeminiAdapter::MODEL_NAME` を `gemini-2.5-flash` に変更

## 確認
- 利用中のAPIキーで `models/gemini-2.5-flash` が利用可能であることを確認済み
