### PR TITLE
feat: E19-03 中尾彬にGroq(Llama 3.3 70B)を導入 #80

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ DYNAMODB_ENDPOINT=http://localhost:8000
 # AI APIs
 GEMINI_API_KEY=your_gemini_api_key_here
 GLM_API_KEY=your_glm_api_key_here
-OPENAI_API_KEY=your_openai_api_key_here
+GROQ_API_KEY=your_groq_api_key_here
 
 # Rails
 RAILS_ENV=development

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ DYNAMODB_ENDPOINT=http://localhost:8000
 # AI APIs
 GEMINI_API_KEY=your-gemini-key
 GLM_API_KEY=your-glm-key
-OPENAI_API_KEY=your-openai-key
+GROQ_API_KEY=your-groq-key
 
 # Frontend
 VITE_API_BASE_URL=/api

--- a/backend/app/adapters/open_ai_adapter.rb
+++ b/backend/app/adapters/open_ai_adapter.rb
@@ -1,19 +1,20 @@
 # frozen_string_literal: true
 
-# OpenAiAdapter - OpenAI GPT-4o-mini API用アダプター
+# OpenAiAdapter - Groq OpenAI互換API用アダプター
 #
 # BaseOpenAiCompatAdapterを継承し、中尾彬風の審査員として投稿を採点します。
+# OpenAI互換エンドポイントとしてGroqを使用します。
 #
-# @see https://platform.openai.com/docs/api-reference/chat
+# @see https://console.groq.com/docs/openai
 class OpenAiAdapter < BaseOpenAiCompatAdapter
   # プロンプトファイルのパス
   PROMPT_PATH = 'app/prompts/nakao.txt'
 
-  # OpenAI APIのベースURL
-  BASE_URL = 'https://api.openai.com'
+  # Groq OpenAI互換APIのベースURL
+  BASE_URL = 'https://api.groq.com/openai/v1'
 
-  # GPT-4o-miniモデル
-  MODEL_NAME = 'gpt-4o-mini'
+  # Llama 3.3 70Bモデル
+  MODEL_NAME = 'llama-3.3-70b-versatile'
 
   private
 
@@ -22,7 +23,7 @@ class OpenAiAdapter < BaseOpenAiCompatAdapter
   end
 
   def api_endpoint
-    'v1/chat/completions'
+    'chat/completions'
   end
 
   def model_name
@@ -30,8 +31,8 @@ class OpenAiAdapter < BaseOpenAiCompatAdapter
   end
 
   def api_key
-    key = ENV.fetch('OPENAI_API_KEY', nil)
-    raise ArgumentError, 'OPENAI_API_KEYが設定されていません' unless key && !key.to_s.strip.empty?
+    key = ENV.fetch('GROQ_API_KEY', nil)
+    raise ArgumentError, 'GROQ_API_KEYが設定されていません' unless key && !key.to_s.strip.empty?
 
     key
   end

--- a/backend/spec/adapters/openai_adapter_spec.rb
+++ b/backend/spec/adapters/openai_adapter_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe OpenAiAdapter do
   describe '定数' do
     it '必要な定数が正しく定義されていること', :aggregate_failures do
       expect(described_class::PROMPT_PATH).to eq('app/prompts/nakao.txt')
-      expect(described_class::BASE_URL).to eq('https://api.openai.com')
-      expect(described_class::MODEL_NAME).to eq('gpt-4o-mini')
+      expect(described_class::BASE_URL).to eq('https://api.groq.com/openai/v1')
+      expect(described_class::MODEL_NAME).to eq('llama-3.3-70b-versatile')
     end
   end
 
@@ -37,11 +37,11 @@ RSpec.describe OpenAiAdapter do
       expect(adapter.send(:client)).to be_a(Faraday::Connection)
     end
 
-    # 何を検証するか: OpenAI APIのベースURLが設定されていること
+    # 何を検証するか: Groq APIのベースURLが設定されていること
 
-    it 'OpenAI APIのベースURLが設定されていること' do
+    it 'Groq APIのベースURLが設定されていること' do
       client = adapter.send(:client)
-      expect(client.url_prefix.to_s).to include('api.openai.com')
+      expect(client.url_prefix.to_s).to include('api.groq.com/openai/v1')
     end
 
     # 何を検証するか: SSL証明書の検証が有効であること
@@ -72,7 +72,7 @@ RSpec.describe OpenAiAdapter do
         request = adapter.send(:build_request, post_content, persona)
 
         expect(request).to be_a(Hash)
-        expect(request[:model]).to eq('gpt-4o-mini')
+        expect(request[:model]).to eq('llama-3.3-70b-versatile')
         expect(request[:messages]).to be_present
       end
 
@@ -86,11 +86,11 @@ RSpec.describe OpenAiAdapter do
         expect(user_content).not_to include('{post_content}')
       end
 
-      # 何を検証するか: modelがgpt-4o-miniに設定されていること
+      # 何を検証するか: modelがllama-3.3-70b-versatileに設定されていること
       # 失敗理由: build_requestメソッドがまだ実装されていないため
-      it 'modelがgpt-4o-miniに設定されていること' do
+      it 'modelがllama-3.3-70b-versatileに設定されていること' do
         request = adapter.send(:build_request, post_content, persona)
-        expect(request[:model]).to eq('gpt-4o-mini')
+        expect(request[:model]).to eq('llama-3.3-70b-versatile')
       end
 
       # 何を検証するか: temperatureが0.7に設定されていること
@@ -118,5 +118,5 @@ RSpec.describe OpenAiAdapter do
   end
 
   # 何を検証するか: APIキーの取得
-  it_behaves_like 'adapter api key validation', 'OPENAI_API_KEY'
+  it_behaves_like 'adapter api key validation', 'GROQ_API_KEY'
 end

--- a/backend/spec/support/vcr.rb
+++ b/backend/spec/support/vcr.rb
@@ -25,6 +25,7 @@ VCR.configure do |config|
   config.filter_sensitive_data('<GEMINI_API_KEY>') { ENV.fetch('GEMINI_API_KEY', nil) }
   config.filter_sensitive_data('<GLM_API_KEY>') { ENV.fetch('GLM_API_KEY', nil) }
   config.filter_sensitive_data('<OPENAI_API_KEY>') { ENV.fetch('OPENAI_API_KEY', nil) }
+  config.filter_sensitive_data('<GROQ_API_KEY>') { ENV.fetch('GROQ_API_KEY', nil) }
 
   # カセットがない場合の挙動
   config.configure_rspec_metadata!


### PR DESCRIPTION
中尾彬審査のOpenAI互換エンドポイントをGroqへ切替。モデルはllama-3.3-70b-versatile、APIキー参照はGROQ_API_KEYへ変更。openai_adapter_specと.env.example/READMEも更新済み。scripts/test_all.shで検証済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * AI APIセクションの環境変数設定例を更新しました。設定例のAPIキーが変更されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->