### PR TITLE
fix: E19-05 Gemini分割レスポンス解析を修正 #80

### DIFF
--- a/backend/app/adapters/gemini_adapter.rb
+++ b/backend/app/adapters/gemini_adapter.rb
@@ -155,12 +155,14 @@ class GeminiAdapter < BaseAiAdapter
     parsed = JSON.parse(body, symbolize_names: true)
 
     candidates = parsed[:candidates]
-    unless candidates&.first&.dig(:content, :parts)&.first&.dig(:text)
+    parts = candidates&.first&.dig(:content, :parts)
+
+    unless parts.is_a?(Array) && parts.any? { |part| part[:text].present? }
       Rails.logger.error('Gemini APIレスポンスにcandidatesが含まれていません')
       raise ArgumentError, 'Invalid candidates structure'
     end
 
-    candidates.first[:content][:parts].first[:text]
+    parts.filter_map { |part| part[:text] }.join
   rescue JSON::ParserError => e
     Rails.logger.error("APIレスポンスのJSONパースエラー: #{e.message}")
     raise

--- a/backend/spec/adapters/gemini_adapter_spec.rb
+++ b/backend/spec/adapters/gemini_adapter_spec.rb
@@ -168,6 +168,28 @@ RSpec.describe GeminiAdapter do
         expect(result[:scores][:empathy]).to be_a(Integer)
       end
 
+      it '複数のpartsに分割されたJSONレスポンスも解析できること' do
+        response_hash = {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { text: "```json\n" },
+                  { text: JSON.generate(base_scores.merge(comment: '分割レスポンス')) },
+                  { text: "\n```" }
+                ]
+              }
+            }
+          ]
+        }
+        faraday_response = build_faraday_response(response_hash)
+
+        result = adapter.send(:parse_response, faraday_response)
+
+        expect(result[:scores]).to eq(base_scores.transform_keys(&:to_sym))
+        expect(result[:comment]).to eq('分割レスポンス')
+      end
+
       # 何を検証するか: 小数点文字列のスコア変換（CodeRabbitレビュー対応）
       context '小数点スコアの扱い' do
         it 'スコアが小数点文字列（"12.5"）の場合に四捨五入して整数に変換できること' do


### PR DESCRIPTION
## 概要
- Geminiレスポンスのparts配列が複数要素に分割されるケースを修正
- ひろゆき審査でコードブロック先頭だけを拾ってinvalid_responseになる不具合を解消
- 回帰テストを追加

## 検証
- bash scripts/test_all.sh