### PR TITLE
fix: DockerfileにImageMagickを追加してOGP画像生成を有効化

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 imagemagick && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment


### PR DESCRIPTION
## 🔧 OGP画像生成の修正

### 📋 概要

OGP画像が正しく生成されない問題を修正しました。

**原因:** DockerfileにImageMagickがインストールされていなかったため、MiniMagickによる画像生成が失敗していた。

---

### 🔄 変更内容

**ファイル:** `backend/Dockerfile`

```dockerfile
# 変更前
apt-get install --no-install-recommends -y curl libjemalloc2

# 変更後
apt-get install --no-install-recommends -y curl libjemalloc2 imagemagick
```

---

### ✅ 期待される結果

デプロイ後、OGP画像が正しく生成されるようになります。

---

### 🧪 検証手順

デプロイ後に以下で確認：

```bash
curl -sI "https://dzt7yd2jha9r3.cloudfront.net/ogp/posts/{post-id}.png"
# content-length が 0 以外であることを確認
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)