### PR TITLE
fix: 審査ポーリングコメントの秒数表記を同期

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -542,7 +542,7 @@ function App() {
 
     const fetchPost = async () => {
       const elapsed = Date.now() - pollingStartedAtRef.current
-      // 監視上限180秒を超えた場合はAPIを呼ばずに終端する。
+      // 監視上限（JUDGING_POLLING_TIMEOUT_MS。現在は60秒）を超えた場合はAPIを呼ばずに終端する。
       if (elapsed >= JUDGING_POLLING_TIMEOUT_MS) {
         handleJudgingFetchFailed()
         return
@@ -573,7 +573,7 @@ function App() {
         }
 
         const retryElapsed = Date.now() - pollingStartedAtRef.current
-        // 500系/通信系は180秒枠内で再試行し、超過時のみ終了する。
+        // 500系/通信系は監視上限（JUDGING_POLLING_TIMEOUT_MS。現在は60秒）内で再試行し、超過時のみ終了する。
         if (retryElapsed >= JUDGING_POLLING_TIMEOUT_MS) {
           handleJudgingFetchFailed()
         }


### PR DESCRIPTION
## 概要
 の審査ポーリングコメントが実装値とズレていたため、実際の  に合わせて修正しました。

## 変更内容
-  のコメントを、実装値  に同期
- 再試行側コメントも同様に同期

## 背景
-  に対してコメントが 180 秒のままで、レビュー上の指摘が入っていたため

## 影響範囲
- コメントのみ
- 挙動変更なし

## 検証
- 対象コードを確認し、実装値とコメントが一致することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ポーリング関連のコメントを整理し、タイムアウト設定の参照をより正確に反映させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->