### PR TITLE
fix: E20-03 backend deploy権限を修正 #92

### DIFF
--- a/backend/terraform/iam_github.tf
+++ b/backend/terraform/iam_github.tf
@@ -147,6 +147,7 @@ resource "aws_iam_role_policy" "backend_github_actions" {
         Effect = "Allow"
         Action = [
           "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
           "lambda:GetFunction",
           "lambda:GetFunctionConfiguration"
         ]


### PR DESCRIPTION
## 概要
GitHub Actions の backend deploy で aws lambda update-function-configuration が AccessDeniedException になる問題を修正します。

## 原因
github-actions-backend-deploy-role に lambda:UpdateFunctionConfiguration 権限がなく、Lambda コード更新後の設定更新ステップだけ失敗していました。

## 変更内容
- backend deploy 用 IAM ポリシーに lambda:UpdateFunctionConfiguration を追加

## 確認内容
- terraform -chdir=backend/terraform validate

## 影響
- backend デプロイ workflow の Lambda 設定更新が通るようになります
- 対象は deploy role の権限追加のみです
