### PR TITLE
fix: E20-03 OGPフォールバックを画像返却に統一 #92

### DIFF
--- a/backend/app/controllers/ogp_controller.rb
+++ b/backend/app/controllers/ogp_controller.rb
@@ -31,8 +31,9 @@ class OgpController < ApplicationController
       # OGP生成がnilを返した場合のフォールバック
       send_default_ogp_image
     end
-  rescue Dynamoid::Errors::RecordNotFound, Dynamoid::Errors::MissingHashKey
-    render_not_found
+  rescue Dynamoid::Errors::RecordNotFound, Dynamoid::Errors::MissingHashKey => e
+    Rails.logger.warn("[OgpController] Dynamoid error for post #{params[:id]}: #{e.message}")
+    send_default_ogp_image
   rescue MiniMagick::Error => e
     # ImageMagick関連エラー時のフォールバック
     Rails.logger.warn("[OgpController] MiniMagick error for post #{params[:id]}: #{e.message}")


### PR DESCRIPTION
## 概要
- Dynamoid例外時に404 JSONではなくデフォルトOGP画像を返すよう修正
- CloudFrontのcustom_error_responseでindex.htmlが返る経路を回避
- OGP画像がCloudFront経由でimage/pngを返すことを確認

## 検証
- DYNAMODB_ENDPOINT=http://127.0.0.1:8002 bundle exec rspec --fail-fast
- bundle exec rspec spec/requests/api/ogp_posts_spec.rb
- bundle exec rubocop --cache false app/controllers/ogp_controller.rb spec/requests/api/ogp_posts_spec.rb
- bundle exec brakeman -q
- terraform plan -lock=false -out=tfplan
- terraform apply -auto-approve tfplan
- aws cloudfront create-invalidation --distribution-id E3IADTV7B5GN3Q --paths '/ogp/*'
- curl -I https://dzt7yd2jha9r3.cloudfront.net/ogp/posts/48e1a743-9643-4ee3-9663-9061491c6ff0.png
- aws cloudfront get-invalidation --distribution-id E3IADTV7B5GN3Q --id I5EP8PX0Z6CADPLDEAZUHH29GD