### PR TITLE
fix: OGP画像S3アップロードのDynamoDB結果的整合性問題を修正

### DIFF
--- a/backend/app/services/concerns/judge_common_concern.rb
+++ b/backend/app/services/concerns/judge_common_concern.rb
@@ -30,8 +30,9 @@ module JudgeCommonConcern
   end
 
   # OGP画像の事前生成を行う
+  # Postオブジェクトを直接渡すことで、DynamoDBの結果的整合性問題を回避
   def upload_ogp_image(post)
-    return if UploadOgpImageService.call(post.id)
+    return if UploadOgpImageService.call(post)
 
     Rails.logger.warn("[#{self.class.name}] OGP画像の事前生成に失敗: post_id=#{post.id}")
   rescue StandardError => e

--- a/backend/app/services/upload_ogp_image_service.rb
+++ b/backend/app/services/upload_ogp_image_service.rb
@@ -5,12 +5,18 @@ class UploadOgpImageService
   OGP_S3_PREFIX = 'ogp/posts'
   CACHE_CONTROL = 'max-age=604800, public'
 
-  def initialize(post_id, s3_client:)
-    @post = Post.find(post_id)
+  # Postオブジェクトまたはpost_idを受け取る
+  # DynamoDBの結果的整合性問題を回避するため、Postオブジェクトを直接渡すことを推奨
+  def initialize(post_or_id, s3_client:)
+    @post = post_or_id.is_a?(Post) ? post_or_id : fetch_post(post_or_id)
     @s3_client = s3_client
+  end
+
+  def fetch_post(post_id)
+    Post.find(post_id)
   rescue Dynamoid::Errors::RecordNotFound, Dynamoid::Errors::MissingHashKey
     Rails.logger.warn("[UploadOgpImageService] Post not found: #{post_id}")
-    @post = nil
+    nil
   end
 
   def execute
@@ -39,10 +45,12 @@ class UploadOgpImageService
   end
 
   class << self
-    def call(post_id, s3_client: nil)
+    # Postオブジェクトまたはpost_idを受け取る
+    # DynamoDBの結果的整合性問題を回避するため、Postオブジェクトを直接渡すことを推奨
+    def call(post_or_id, s3_client: nil)
       return false if bucket_name.empty?
 
-      new(post_id, s3_client: s3_client || build_s3_client).execute
+      new(post_or_id, s3_client: s3_client || build_s3_client).execute
     end
 
     private

--- a/backend/spec/services/judge_post_service_spec.rb
+++ b/backend/spec/services/judge_post_service_spec.rb
@@ -70,28 +70,28 @@ RSpec.describe JudgePostService do
       # 何を検証するか: 3人全員成功時にstatus: scoredになること
       it '3人全員成功時にstatus: scoredになること' do
         mock_all_adapters_success
-        allow(UploadOgpImageService).to receive(:call).with(post.id).and_return(true)
+        allow(UploadOgpImageService).to receive(:call).with(instance_of(Post)).and_return(true)
 
         service.execute
 
         post.reload
         expect(post.status).to eq('scored')
         expect(post.judges_count).to eq(3)
-        expect(UploadOgpImageService).to have_received(:call).with(post.id)
+        expect(UploadOgpImageService).to have_received(:call).with(instance_of(Post))
       end
 
       # 何を検証するか: 2人成功時にstatus: scoredになること
       it '2人成功時にstatus: scoredになること' do
         mock_all_adapters_success
         mock_adapter_failure(OpenAiAdapter)
-        allow(UploadOgpImageService).to receive(:call).with(post.id).and_return(true)
+        allow(UploadOgpImageService).to receive(:call).with(instance_of(Post)).and_return(true)
 
         service.execute
 
         post.reload
         expect(post.status).to eq('scored')
         expect(post.judges_count).to eq(2)
-        expect(UploadOgpImageService).to have_received(:call).with(post.id)
+        expect(UploadOgpImageService).to have_received(:call).with(instance_of(Post))
       end
 
       # 何を検証するか: 平均点が小数第1位に丸められること
@@ -109,7 +109,7 @@ RSpec.describe JudgePostService do
           create_success_response(scores: { empathy: 15, humor: 15, brevity: 15, originality: 15, expression: 15 },
                                   comment: 'test')
         )
-        allow(UploadOgpImageService).to receive(:call).with(post.id).and_return(true)
+        allow(UploadOgpImageService).to receive(:call).with(instance_of(Post)).and_return(true)
 
         service.execute
 
@@ -218,7 +218,7 @@ RSpec.describe JudgePostService do
 
       it 'OGP生成に失敗しても審査結果はscoredのまま継続すること' do
         mock_all_adapters_success
-        allow(UploadOgpImageService).to receive(:call).with(post.id).and_return(false)
+        allow(UploadOgpImageService).to receive(:call).with(instance_of(Post)).and_return(false)
         expect(Rails.logger).to receive(:warn).with(/\[JudgePostService\] OGP画像の事前生成に失敗: post_id=#{post.id}/)
 
         service.execute

--- a/backend/spec/services/rejudge_post_service_spec.rb
+++ b/backend/spec/services/rejudge_post_service_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'RejudgePostService', type: :service do
             comment: '再審査成功'
           )
         )
-        allow(UploadOgpImageService).to receive(:call).with(post_record.id).and_return(true)
+        allow(UploadOgpImageService).to receive(:call).with(instance_of(Post)).and_return(true)
 
         service_class.new(post_record.id, failed_personas: ['dewi']).execute
 
@@ -83,7 +83,7 @@ RSpec.describe 'RejudgePostService', type: :service do
 
         expect(personas).to include('hiroyuki', 'dewi')
         expect(post_record.status).to eq('scored')
-        expect(UploadOgpImageService).to have_received(:call).with(post_record.id)
+        expect(UploadOgpImageService).to have_received(:call).with(instance_of(Post))
       end
 
       # 何を検証するか: 複数personaの再審査成功時に平均点を再計算してscoredになること
@@ -105,14 +105,14 @@ RSpec.describe 'RejudgePostService', type: :service do
             comment: '再審査成功'
           )
         )
-        allow(UploadOgpImageService).to receive(:call).with(post_record.id).and_return(true)
+        allow(UploadOgpImageService).to receive(:call).with(instance_of(Post)).and_return(true)
 
         service_class.new(post_record.id, failed_personas: %w[dewi nakao]).execute
 
         post_record.reload
         expect(post_record.status).to eq('scored')
         expect(post_record.average_score).to be_present
-        expect(UploadOgpImageService).to have_received(:call).with(post_record.id)
+        expect(UploadOgpImageService).to have_received(:call).with(instance_of(Post))
       end
     end
 


### PR DESCRIPTION
## Summary
- 審査完了時のOGP画像S3アップロードが失敗する問題を修正
- DynamoDBの結果的整合性により、`Post.find(post_id)`で古いデータが返される問題を回避

## 変更内容
- `UploadOgpImageService`がPostオブジェクトまたはpost_idを受け取れるように変更
- `JudgeCommonConcern`からPostオブジェクトを直接渡すように変更
- テストのモックを更新

## テスト結果
- 694 examples, 0 failures

## Test plan
- [ ] 本番環境でテスト投稿を作成
- [ ] CloudWatchログで`[UploadOgpImageService] OGP画像アップロード成功`を確認
- [ ] S3バケットに画像がアップロードされていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)