### PR TITLE
fix: ResultModalのcreated_at型不整合を修正

### DIFF
--- a/frontend/src/features/result/components/ResultModal.tsx
+++ b/frontend/src/features/result/components/ResultModal.tsx
@@ -81,7 +81,7 @@ function buildOgpImageUrl(postId: string): string {
   return `${FRONTEND_BASE_URL}/ogp/posts/${postId}.png`
 }
 
-function parseCreatedAtMs(createdAt: Post['created_at']): number | null {
+function parseCreatedAtMs(createdAt: Post['created_at'] | undefined): number | null {
   if (!createdAt) return null
 
   // 純粋な数字文字列のみをUnixタイムスタンプとして扱う
@@ -95,7 +95,10 @@ function parseCreatedAtMs(createdAt: Post['created_at']): number | null {
   return Number.isNaN(parsedMs) ? null : parsedMs
 }
 
-function resolveInitialShareDelayMs(createdAt: Post['created_at'], canShowShare: boolean): number {
+function resolveInitialShareDelayMs(
+  createdAt: Post['created_at'] | undefined,
+  canShowShare: boolean
+): number {
   if (!canShowShare) return 0
 
   const createdAtMs = parseCreatedAtMs(createdAt)


### PR DESCRIPTION
## 概要
- post?.created_at が undefined になり得る経路に合わせて、ResultModal内の日時変換ヘルパーの引数型を修正
- frontend の npm run build 時に出ていた TypeScript の TS2345 を解消

## 背景
- 直前のPRは、古いローカル main から分岐した使い回しブランチ全体をそのまま main に向けてPR化していたため、既に main に取り込まれた差分と未整理の差分が混在し、コンフリクトしやすい状態でした
- 今回は最新の origin/main（2026-03-02 時点で 660fa1ad）から新規ブランチを作り、この修正コミットのみを載せています

## テスト
- 元ワークツリーで同内容に対して frontend で npm run build 通過済み
- 新規 worktree 側は node_modules 未配置のため tsc 実行不可


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 投稿の作成日時データが欠落している場合の処理を改善し、より安定した動作を実現しました。
  * 共有機能の初期遅延処理をより堅牢にし、不完全なデータでも安全に処理できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->