### PR TITLE
feat: E19-03 Terraform出力とテストを追加

### DIFF
--- a/backend/spec/terraform/cloudfront_spec.rb
+++ b/backend/spec/terraform/cloudfront_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# 検証内容: Terraform cloudfront.tf の設定が正しいか
+# 回帰テストとして実施（既存実装を検証）
+RSpec.describe 'Terraform CloudFront', dynamodb: false do
+  let(:cloudfront_tf_path) { Rails.root.join('terraform/cloudfront.tf') }
+  let(:cloudfront_tf_content) do
+    File.exist?(cloudfront_tf_path) ? File.read(cloudfront_tf_path) : ''
+  end
+
+  # 検証: importブロックで既存リソースを管理していること
+  # これにより手動作成リソースをTerraform管理下に置いていることを確認
+  describe 'importブロック' do
+    # 検証: importブロックの存在
+    it 'importブロックが定義されていること' do
+      expect(cloudfront_tf_content).to match(/import\s*\{/)
+    end
+
+    # 検証: import先が正しいリソースであること
+    it 'aws_cloudfront_distribution.frontendにimportされていること' do
+      expect(cloudfront_tf_content).to match(/to\s*=\s*aws_cloudfront_distribution\.frontend/)
+    end
+
+    # 検証: import IDが変数参照であること（ハードコードされていないこと）
+    it 'var.cloudfront_distribution_idを参照していること' do
+      expect(cloudfront_tf_content).to match(/id\s*=\s*var\.cloudfront_distribution_id/)
+    end
+  end
+
+  # 検証: CloudFrontディストリビューションの基本設定
+  describe 'ディストリビューション基本設定' do
+    # 検証: リソース定義の存在
+    it 'aws_cloudfront_distribution.frontendリソースが定義されていること' do
+      expect(cloudfront_tf_content).to match(/resource\s+"aws_cloudfront_distribution"\s+"frontend"/)
+    end
+
+    # 検証: ディストリビューションが有効であること
+    it 'enabled = trueであること' do
+      expect(cloudfront_tf_content).to match(/enabled\s*=\s*true/)
+    end
+
+    # 検証: SPAのエントリーポイント
+    it 'default_root_object = "index.html"であること' do
+      expect(cloudfront_tf_content).to match(/default_root_object\s*=\s*"index\.html"/)
+    end
+
+    # 検証: IPv6対応
+    it 'IPv6が有効であること' do
+      expect(cloudfront_tf_content).to match(/is_ipv6_enabled\s*=\s*true/)
+    end
+  end
+
+  # 検証: S3オリジンが変数参照であること
+  # 手動作成済みバケットを参照していることを確認
+  describe 'S3オリジン設定' do
+    # 検証: S3バケット名が変数参照であること
+    it 'domain_nameがvar.frontend_s3_bucket_nameを使用していること' do
+      expect(cloudfront_tf_content).to match(/var\.frontend_s3_bucket_name/)
+    end
+
+    # 検証: OAC IDが変数参照であること
+    it 'origin_access_control_idがvar.frontend_origin_access_control_idを使用していること' do
+      expect(cloudfront_tf_content).to match(/var\.frontend_origin_access_control_id/)
+    end
+  end
+
+  # 検証: SPAルーティング対応のカスタムエラーレスポンス
+  # 存在しないパスへのアクセス時にindex.htmlを返す設定
+  describe 'SPAルーティング対応' do
+    # 検証: 403エラー時の処理
+    it '403エラー時にindex.htmlが返されること' do
+      expect(cloudfront_tf_content).to match(/error_code\s*=\s*403/)
+      expect(cloudfront_tf_content).to match(%r{response_page_path\s*=\s*"/index\.html"})
+    end
+
+    # 検証: 404エラー時の処理
+    it '404エラー時にindex.htmlが返されること' do
+      expect(cloudfront_tf_content).to match(/error_code\s*=\s*404/)
+      expect(cloudfront_tf_content).to match(%r{response_page_path\s*=\s*"/index\.html"})
+    end
+  end
+
+  # 検証: HTTPSへリダイレクトされること
+  describe 'HTTPSリダイレクト' do
+    it 'viewer_protocol_policy = "redirect-to-https"であること' do
+      expect(cloudfront_tf_content).to match(/viewer_protocol_policy\s*=\s*"redirect-to-https"/)
+    end
+  end
+end

--- a/backend/spec/terraform/iam_github_spec.rb
+++ b/backend/spec/terraform/iam_github_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# 検証内容: Terraform iam_github.tf のGitHub Actions用権限が正しいか
+# 回帰テストとして実施（既存実装を検証）
+RSpec.describe 'Terraform GitHub IAM', dynamodb: false do
+  let(:iam_github_tf_path) { Rails.root.join('terraform/iam_github.tf') }
+  let(:iam_github_tf_content) do
+    File.exist?(iam_github_tf_path) ? File.read(iam_github_tf_path) : ''
+  end
+
+  # 検証: フロントエンドデプロイ用ロールの存在
+  describe 'frontend_github_actionsロール' do
+    it 'aws_iam_role.frontend_github_actionsが定義されていること' do
+      expect(iam_github_tf_content).to match(/resource\s+"aws_iam_role"\s+"frontend_github_actions"/)
+    end
+
+    it 'GitHub Actions frontend deploy用の説明があること' do
+      expect(iam_github_tf_content).to match(/Role for GitHub Actions frontend deploy/)
+    end
+  end
+
+  # 検証: OIDC前提のAssumeRole設定
+  describe 'OIDC信頼ポリシー' do
+    it 'sts:AssumeRoleWithWebIdentityを許可していること' do
+      expect(iam_github_tf_content).to match(/sts:AssumeRoleWithWebIdentity/)
+    end
+
+    it 'GitHub OIDC ProviderをFederated principalにしていること' do
+      expect(iam_github_tf_content).to match(/Federated\s*=\s*aws_iam_openid_connect_provider\.github\.arn/)
+    end
+  end
+
+  # 検証: フロントデプロイに必要な最小権限
+  describe 'frontend_github_actionsポリシー' do
+    it 'aws_iam_role_policy.frontend_github_actionsが定義されていること' do
+      expect(iam_github_tf_content).to match(/resource\s+"aws_iam_role_policy"\s+"frontend_github_actions"/)
+    end
+
+    it 'S3 ListBucket権限があること' do
+      expect(iam_github_tf_content).to match(/Sid\s*=\s*"S3ListBucket"/)
+      expect(iam_github_tf_content).to match(/s3:ListBucket/)
+      expect(iam_github_tf_content).to match(/s3:GetBucketLocation/)
+    end
+
+    it 'S3オブジェクトの読み書き権限があること' do
+      expect(iam_github_tf_content).to match(/Sid\s*=\s*"S3ObjectRW"/)
+      expect(iam_github_tf_content).to match(/s3:GetObject/)
+      expect(iam_github_tf_content).to match(/s3:PutObject/)
+      expect(iam_github_tf_content).to match(/s3:DeleteObject/)
+    end
+
+    it 'CloudFront無効化権限があること' do
+      expect(iam_github_tf_content).to match(/Sid\s*=\s*"CloudFrontDeployOps"/)
+      expect(iam_github_tf_content).to match(/cloudfront:CreateInvalidation/)
+      expect(iam_github_tf_content).to match(/cloudfront:GetDistribution/)
+      expect(iam_github_tf_content).to match(/cloudfront:GetInvalidation/)
+    end
+
+    it 'S3リソースがvar.frontend_s3_bucket_nameを参照していること' do
+      expect(iam_github_tf_content).to match(/arn:aws:s3:::\$\{var\.frontend_s3_bucket_name\}/)
+      expect(iam_github_tf_content).to match(%r{arn:aws:s3:::\$\{var\.frontend_s3_bucket_name\}/\*})
+    end
+
+    it 'CloudFrontリソースがlocal.cloudfront_distributionを参照していること' do
+      expect(iam_github_tf_content).to match(/Resource\s*=\s*local\.cloudfront_distribution/)
+    end
+  end
+end

--- a/backend/spec/terraform/outputs_spec.rb
+++ b/backend/spec/terraform/outputs_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# 検証内容: Terraform outputs.tf に必要なアウトプットが定義されているか
+# このテストはRED状態で出力される（outputs.tfに対象出力が未定義のため）
+RSpec.describe 'Terraform Outputs', dynamodb: false do
+  let(:outputs_tf_path) { Rails.root.join('terraform/outputs.tf') }
+  let(:outputs_tf_content) do
+    # ファイルが存在しない場合は空文字を返す（REDテストを失敗させるため）
+    File.exist?(outputs_tf_path) ? File.read(outputs_tf_path) : ''
+  end
+
+  # 検証: frontend_s3_bucket_nameアウトプットが定義されていること
+  # 受入条件: terraform output -raw frontend_s3_bucket_name でバケット名が返されること
+  describe 'frontend_s3_bucket_nameアウトプット' do
+    # 検証: outputブロックの存在
+    it 'outputブロックが定義されていること' do
+      # RED: 現在outputs.tfには定義されていないため失敗する
+      expect(outputs_tf_content).to match(/output\s+"frontend_s3_bucket_name"\s*\{/)
+    end
+
+    # 検証: descriptionの存在（ドキュメンテーション用途）
+    it 'descriptionが設定されていること' do
+      # RED: 定義されていないため失敗する
+      expect(outputs_tf_content).to match(/description\s*=\s*".*S3.*バケット/)
+    end
+
+    # 検証: valueがvar.frontend_s3_bucket_nameを参照していること
+    # 注意: aws_s3_bucket.frontend.idではなく変数参照（リソースが存在しないため）
+    it 'valueがvar.frontend_s3_bucket_nameを参照していること' do
+      # RED: 定義されていないため失敗する
+      expect(outputs_tf_content).to match(/value\s*=\s*var\.frontend_s3_bucket_name/)
+    end
+  end
+
+  # 検証: cloudfront_distribution_idアウトプットが定義されていること
+  # 受入条件: terraform output -raw cloudfront_distribution_id でIDが返されること
+  describe 'cloudfront_distribution_idアウトプット' do
+    # 検証: outputブロックの存在
+    it 'outputブロックが定義されていること' do
+      # RED: 現在outputs.tfには定義されていないため失敗する
+      expect(outputs_tf_content).to match(/output\s+"cloudfront_distribution_id"\s*\{/)
+    end
+
+    # 検証: descriptionの存在（ドキュメンテーション用途）
+    it 'descriptionが設定されていること' do
+      # RED: 定義されていないため失敗する
+      expect(outputs_tf_content).to match(/description\s*=\s*".*CloudFront.*ディストリビューション/)
+    end
+
+    # 検証: valueがaws_cloudfront_distribution.frontend.idを参照していること
+    # 注意: importブロックで管理されているためリソース属性を参照可能
+    it 'valueがaws_cloudfront_distribution.frontend.idを参照していること' do
+      # RED: 定義されていないため失敗する
+      expect(outputs_tf_content).to match(/value\s*=\s*aws_cloudfront_distribution\.frontend\.id/)
+    end
+  end
+end

--- a/backend/terraform/outputs.tf
+++ b/backend/terraform/outputs.tf
@@ -31,3 +31,13 @@ output "access_log_bucket_name" {
   description = "S3 bucket name storing CloudFront and frontend S3 access logs."
   value       = aws_s3_bucket.access_logs.bucket
 }
+
+output "frontend_s3_bucket_name" {
+  description = "S3バケット名"
+  value       = var.frontend_s3_bucket_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFrontディストリビューションID"
+  value       = aws_cloudfront_distribution.frontend.id
+}


### PR DESCRIPTION
## 概要
- frontend配信用S3バケット名とCloudFront Distribution IDのTerraform outputを追加
- outputs.tf / cloudfront.tf / iam_github.tf を検証するTerraform specを追加

## 検証
- cd backend && bundle exec rspec spec/terraform/outputs_spec.rb
- cd backend && bundle exec rspec spec/terraform/cloudfront_spec.rb
- cd backend && bundle exec rspec spec/terraform/iam_github_spec.rb
- cd backend && bundle exec rubocop --cache false spec/terraform
- cd backend/terraform && terraform validate