### PR TITLE
chore: E09 連続投稿制限を開発用に5秒へ緩和

### DIFF
--- a/backend/app/services/rate_limiter_service.rb
+++ b/backend/app/services/rate_limiter_service.rb
@@ -5,7 +5,7 @@
 # IPアドレスとニックネームの両方に対して5分間の投稿制限を設ける
 class RateLimiterService
   # 定数
-  LIMIT_DURATION = 300
+  LIMIT_DURATION = 5 # TODO: 開発の利便性のため一時的に5秒に変更（本来は 300）
 
   # ログ出力用のハッシュインデックス
   HASH_LOG_START_INDEX = 3  # ハッシュの開始位置（ログ出力用）

--- a/backend/spec/services/rate_limiter_service_spec.rb
+++ b/backend/spec/services/rate_limiter_service_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe RateLimiterService, type: :service do
 
   # 何を検証するか: 定数が定義されていること
   describe '定数' do
-    it 'LIMIT_DURATION定数が300秒で定義されていること' do
-      expect(described_class::LIMIT_DURATION).to eq(300)
+    it 'LIMIT_DURATION定数が定義されていること' do
+      expect(described_class::LIMIT_DURATION).to be_a(Integer)
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe RateLimiterService, type: :service do
       # When: limited?を呼び出す
       # Then: trueを返す（ニックネームは未制限でも）
       it 'IP制限中の場合、trueを返すこと' do
-        create(:rate_limit, identifier: ip_identifier, expires_at: current_time + 300)
+        create(:rate_limit, identifier: ip_identifier, expires_at: current_time + described_class::LIMIT_DURATION)
         expect(described_class.limited?(ip: ip, nickname: nickname)).to be true
       end
 
@@ -48,7 +48,7 @@ RSpec.describe RateLimiterService, type: :service do
       # When: limited?を呼び出す
       # Then: trueを返す（IPは未制限でも）
       it 'ニックネーム制限中の場合、trueを返すこと' do
-        create(:rate_limit, identifier: nickname_identifier, expires_at: current_time + 300)
+        create(:rate_limit, identifier: nickname_identifier, expires_at: current_time + described_class::LIMIT_DURATION)
         expect(described_class.limited?(ip: ip, nickname: nickname)).to be true
       end
 
@@ -56,8 +56,8 @@ RSpec.describe RateLimiterService, type: :service do
       # When: limited?を呼び出す
       # Then: trueを返す
       it 'IPとニックネーム両方が制限中の場合、trueを返すこと' do
-        create(:rate_limit, identifier: ip_identifier, expires_at: current_time + 300)
-        create(:rate_limit, identifier: nickname_identifier, expires_at: current_time + 300)
+        create(:rate_limit, identifier: ip_identifier, expires_at: current_time + described_class::LIMIT_DURATION)
+        create(:rate_limit, identifier: nickname_identifier, expires_at: current_time + described_class::LIMIT_DURATION)
         expect(described_class.limited?(ip: ip, nickname: nickname)).to be true
       end
     end
@@ -141,7 +141,7 @@ RSpec.describe RateLimiterService, type: :service do
       # Given: IP・ニックネームともに制限なし
       # When: set_limit!を呼び出す
       # Then: expires_atが現在時刻+300秒に設定される（Integer型）
-      it 'expires_atが現在時刻+300秒のInteger型で設定されること' do
+      it 'expires_atが現在時刻+設定値のInteger型で設定されること' do
         current_time = Time.current.to_i
         described_class.set_limit!(ip: ip, nickname: nickname)
 
@@ -150,22 +150,22 @@ RSpec.describe RateLimiterService, type: :service do
 
         # Integer型であることを検証（String型の".to_s"ではないこと）
         expect(ip_limit.expires_at).to be_a(Integer)
-        expect(ip_limit.expires_at).to be_within(1).of(current_time + 300)
+        expect(ip_limit.expires_at).to be_within(1).of(current_time + described_class::LIMIT_DURATION)
         expect(nickname_limit.expires_at).to be_a(Integer)
-        expect(nickname_limit.expires_at).to be_within(1).of(current_time + 300)
+        expect(nickname_limit.expires_at).to be_within(1).of(current_time + described_class::LIMIT_DURATION)
       end
 
       # Given: IPが既に制限中（同一IPで2回目のset_limit!）
       # When: set_limit!を呼び出す
       # Then: IPレコードのexpires_atが更新される（上書き）
       it '既に制限中のIPのexpires_atが更新されること' do
-        old_time = Time.current.to_i + 100
+        old_time = Time.current.to_i + 1
         create(:rate_limit, identifier: ip_identifier, expires_at: old_time)
 
         described_class.set_limit!(ip: ip, nickname: nickname)
 
         ip_limit = RateLimit.find(ip_identifier)
-        expect(ip_limit.expires_at).to be > old_time
+        expect(ip_limit.expires_at).to be_within(1).of(Time.current.to_i + described_class::LIMIT_DURATION)
       end
     end
 


### PR DESCRIPTION
開発時のテストを容易にするために、一時的に5分間から5秒間へ緩和しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * レート制限の時間ウィンドウを調整しました。

* **Tests**
  * レート制限テストをマイグレーションし、設定値を使用するよう更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->