### PR TITLE
fix: E24-05 JudgeSpeechBubbleのtestId型整合を修正 #136

### DIFF
--- a/frontend/src/features/judging/components/JudgeSpeechBubble.tsx
+++ b/frontend/src/features/judging/components/JudgeSpeechBubble.tsx
@@ -1,45 +1,43 @@
-import { AnimatePresence, motion } from "framer-motion";
-import { JUDGE_SPEECH } from "../../../shared/constants/animations";
-import type { JudgePersona } from "../../../shared/types/domain";
+import { AnimatePresence, motion } from 'framer-motion'
+import { JUDGE_SPEECH } from '../../../shared/constants/animations'
+import type { JudgePersona } from '../../../shared/types/domain'
 
 interface JudgeSpeechBubbleProps {
-	isVisible: boolean;
-	text: string;
-	judgeType: JudgePersona;
+  isVisible: boolean
+  text: string
+  judgeType: JudgePersona
+  testId?: string
 }
 
-const BUBBLE_VARIANTS = JUDGE_SPEECH.BUBBLE_VARIANTS;
+const BUBBLE_VARIANTS = JUDGE_SPEECH.BUBBLE_VARIANTS
 
 const POSITION_CLASSES: Record<JudgePersona, string> = {
-	hiroyuki: "justify-center",
-	dewi: "justify-center",
-	nakao: "justify-start",
-};
+  hiroyuki: 'justify-center',
+  dewi: 'justify-center',
+  nakao: 'justify-start',
+}
 
 /**
  * 審査員の吹き出しを表示するコンポーネント
  */
-export function JudgeSpeechBubble({
-	isVisible,
-	text,
-	judgeType,
-}: JudgeSpeechBubbleProps) {
-	return (
-		<AnimatePresence>
-			{isVisible && (
-				<div className={`flex ${POSITION_CLASSES[judgeType]} mb-2`}>
-					<motion.div
-						role="status"
-						aria-live="polite"
-						initial={BUBBLE_VARIANTS.initial}
-						animate={BUBBLE_VARIANTS.animate}
-						exit={BUBBLE_VARIANTS.exit}
-						className="whitespace-normal rounded-lg bg-white px-3 py-2 text-sm shadow-md"
-					>
-						{text}
-					</motion.div>
-				</div>
-			)}
-		</AnimatePresence>
-	);
+export function JudgeSpeechBubble({ isVisible, text, judgeType, testId }: JudgeSpeechBubbleProps) {
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <div className={`flex ${POSITION_CLASSES[judgeType]} mb-2`}>
+          <motion.div
+            role="status"
+            aria-live="polite"
+            data-testid={testId}
+            initial={BUBBLE_VARIANTS.initial}
+            animate={BUBBLE_VARIANTS.animate}
+            exit={BUBBLE_VARIANTS.exit}
+            className="whitespace-normal rounded-lg bg-white px-3 py-2 text-sm shadow-md"
+          >
+            {text}
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  )
 }


### PR DESCRIPTION
## 概要
CodeRabbit指摘への追加対応として、審査吹き出しコンポーネントと関連箇所の型整合を修正しました。

## 変更内容
- `frontend/src/features/judging/components/JudgeSpeechBubble.tsx`
  - `JudgeSpeechBubbleProps` に `testId?: string` を追加
  - 吹き出し要素へ `data-testid={testId}` を付与
- `frontend/src/features/judging/components/JudgeAvatars.tsx`
  - `JudgeSpeechBubble` 呼び出しの `testId` 受け渡しとの型整合を維持
- `frontend/src/features/top/components/PostFormModal.tsx`
  - （同ブランチ差分として）submit再入防止とキーボードイベント意図明確化を含む修正

## 確認
- `cd frontend && npx tsc --noEmit` で型チェック通過


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テスト環境向けの内部改善を実施しました。

---

**注記**: このリリースは主に開発チームの効率化を目的とした変更であり、エンドユーザーへの機能面での影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->