### PR TITLE
fix: EP39-01 CodeRabbit指摘を反映 #39

### DIFF
--- a/.github/dynamic_ogp_handoff_2026-03-14.md
+++ b/.github/dynamic_ogp_handoff_2026-03-14.md
@@ -1,0 +1,233 @@
+# 動的OGP 引継ぎ資料
+
+作成日: 2026-03-14
+
+## 目的
+
+本番で「投稿詳細の動的OGP画像が表示されない」件について、別セッションでそのまま調査を継続できるように、現時点の事実・仮説・確認手順を整理する。
+
+## 結論サマリ
+
+- ローカル実装ベースでは、動的OGPの Rails 側ロジックが直近変更で破綻した形跡は確認できていない
+- 本番で画像が出ない主因として最有力なのは、`/ogp/posts/:id.png` の実体PNGが frontend 用 S3 に存在しないこと
+- 本番 CloudFront 配信は Rails `OgpController` 直配信ではなく、`frontend S3 -> CloudFront` の静的配信が主経路
+- そのため、OGP HTML の `og:image` が `/ogp/posts/<POST_ID>.png` を指していても、S3 側にファイルが無ければ CloudFront の SPA fallback で `index.html` が返り、「画像が表示されない」状態になりうる
+
+## 重要な理解
+
+### 1. 本番の主経路
+
+- クローラーが投稿URLへ来る
+- CloudFront + Lambda@Edge でクローラー判定
+- Rails API が OGP HTML を返す
+- HTML 内の `og:image` / `twitter:image` は `/ogp/posts/<POST_ID>.png`
+- その PNG は本番では frontend 用 S3 バケットの `ogp/posts/` 配下から CloudFront 経由で静的配信される
+
+根拠:
+
+- [docs/deploy/frontend.md](/home/nukon/ws/aruaruarena/docs/deploy/frontend.md)
+- [README.md](/home/nukon/ws/aruaruarena/README.md)
+- [backend/app/services/upload_ogp_image_service.rb](/home/nukon/ws/aruaruarena/backend/app/services/upload_ogp_image_service.rb)
+
+### 2. Rails `OgpController` は本番主経路ではない
+
+- [backend/app/controllers/ogp_controller.rb](/home/nukon/ws/aruaruarena/backend/app/controllers/ogp_controller.rb) はまだ存在する
+- ただし設計上、本番 CloudFront の主経路では `frontend S3` の `ogp/posts/*.png` が使われる
+- そのため、ローカル request spec が通っていても、本番の画像欠損は起こりうる
+
+### 3. 画像欠損時の危険な挙動
+
+- frontend CloudFront には SPA 用の `403/404 -> /index.html` fallback がある
+- `ogp/posts/<POST_ID>.png` が S3 に存在しない場合、PNG ではなく `index.html` が返る可能性がある
+- SNS クローラーから見ると「画像URLなのに画像が来ない」状態になる
+
+根拠:
+
+- [docs/deploy/frontend.md](/home/nukon/ws/aruaruarena/docs/deploy/frontend.md)
+- [ .github/EP36-01_ogp_best_practices_review_plan.md ](/home/nukon/ws/aruaruarena/.github/EP36-01_ogp_best_practices_review_plan.md)
+
+## 確認済み事項
+
+### A. OGP HTML 生成ロジック
+
+- [backend/app/services/ogp_meta_tag_service.rb](/home/nukon/ws/aruaruarena/backend/app/services/ogp_meta_tag_service.rb) は以下を返す
+  - `og:image` = `#{base_url}/ogp/posts/#{post.id}.png`
+  - `twitter:image` = 同上
+  - `og:image:width` = `1200`
+  - `og:image:height` = `630`
+
+### B. OGP画像アップロードロジック
+
+- [backend/app/services/upload_ogp_image_service.rb](/home/nukon/ws/aruaruarena/backend/app/services/upload_ogp_image_service.rb)
+- `scored` 投稿のみ S3 に `ogp/posts/<POST_ID>.png` を保存する
+- `CreateCloudFrontInvalidationService` で個別 invalidation する
+- 失敗時は `false` を返す
+
+### C. 投稿採点からの呼び出し
+
+- [backend/app/services/concerns/judge_common_concern.rb](/home/nukon/ws/aruaruarena/backend/app/services/concerns/judge_common_concern.rb)
+- `persist_scored_post!` 内で `upload_ogp_image(post)` を呼ぶ
+- ここでアップロード失敗しても投稿は `scored` に進みうる
+- つまり「投稿は公開済みだがOGP画像だけ無い」状態はありうる
+
+### D. 環境変数
+
+- Terraform 上は Lambda に以下を入れる想定
+  - `OGP_S3_BUCKET`
+  - `CLOUDFRONT_DISTRIBUTION_ID`
+
+根拠:
+
+- [backend/terraform/lambda.tf](/home/nukon/ws/aruaruarena/backend/terraform/lambda.tf)
+
+### E. GitHub Actions の backend deploy
+
+- [ .github/workflows/deploy.yml ](/home/nukon/ws/aruaruarena/.github/workflows/deploy.yml) は Lambda のコード更新と timeout 更新のみ
+- この workflow 自体は `OGP_S3_BUCKET` を明示的に設定していない
+- 実運用では Lambda 側に既存設定が残っていれば動くが、未設定やズレがあっても workflow からは見えない
+
+## ローカルで確認したテスト結果
+
+### 実行したもの
+
+```bash
+cd backend && bundle exec rspec spec/requests/api/ogp_posts_spec.rb spec/services/upload_ogp_image_service_spec.rb spec/requests/api/posts_meta_tags_spec.rb
+```
+
+### 結果
+
+- `69 examples, 0 failures, 2 pending`
+- ただし SimpleCov の全体閾値未達で exit 2
+
+### 解釈
+
+- Rails 側の request / service 実装は、少なくともローカルテストでは破綻していない
+- 本番症状はアプリコードの即時破綻より、配信経路・S3欠損・環境変数・既存投稿未補完が本命
+
+## 現時点の最有力原因候補
+
+### 第一候補: S3 に OGP PNG が存在しない
+
+ありえる原因:
+
+- `OGP_S3_BUCKET` 未設定
+- `UploadOgpImageService` 実行失敗
+- `OgpGeneratorService` が nil を返した
+- 過去投稿が事前生成導入前に作られており、補完されていない
+
+### 第二候補: CloudFront が古いキャッシュまたは fallback を返している
+
+ありえる原因:
+
+- invalidation 未実行または失敗
+- 旧キャッシュ残存
+- S3 欠損により `index.html` fallback
+
+### 第三候補: 既存投稿の再生成漏れ
+
+ありえる原因:
+
+- 既存投稿は `scored` 済みだが、`ogp/posts/<POST_ID>.png` が一度も作成されていない
+- ドキュメント上は `scripts/regenerate_all_ogps.rb` で補完する想定
+
+## まずやるべき本番確認
+
+`<POST_ID>`、`<CLOUDFRONT_DOMAIN>`、`<API_GATEWAY_ENDPOINT>`、`<S3_BUCKET_FRONTEND>` を実値に置き換えること。
+
+### 1. API Gateway 側の OGP HTML を確認
+
+```bash
+curl -i -A "Twitterbot/1.0" \
+  https://${API_GATEWAY_ENDPOINT}/api/posts/<POST_ID>
+```
+
+見る点:
+
+- `200`
+- `content-type: text/html`
+- `og:image` が `/ogp/posts/<POST_ID>.png` を指している
+
+### 2. CloudFront 側の OGP HTML を確認
+
+```bash
+curl -i -A "Twitterbot/1.0" \
+  https://${CLOUDFRONT_DOMAIN}/posts/<POST_ID>
+```
+
+見る点:
+
+- `200`
+- OGP HTML が返る
+- `index.html` ではなく OGP 用 HTML になっている
+
+### 3. OGP画像 URL 自体を確認
+
+```bash
+curl -I https://${CLOUDFRONT_DOMAIN}/ogp/posts/<POST_ID>.png
+```
+
+見る点:
+
+- `200`
+- `content-type: image/png`
+- `cache-control: max-age=604800, public`
+
+もし `text/html` や `index.html` 相当が返るなら、S3 欠損 + SPA fallback の可能性が高い。
+
+### 4. S3 に実体があるか確認
+
+```bash
+aws s3 ls s3://${S3_BUCKET_FRONTEND}/ogp/posts/<POST_ID>.png
+```
+
+見る点:
+
+- ファイルが存在するか
+- 更新時刻が最近か
+
+### 5. Lambda / アプリログを確認
+
+CloudWatch Logs で以下を探す:
+
+- `UploadOgpImageService`
+- `OGP_S3_BUCKET environment variable is not set`
+- `OGP画像アップロード成功`
+- `OgpGeneratorService`
+- `CreateCloudFrontInvalidationService`
+
+## 次セッションで優先して見るべきコード
+
+- [backend/app/services/upload_ogp_image_service.rb](/home/nukon/ws/aruaruarena/backend/app/services/upload_ogp_image_service.rb)
+- [backend/app/services/concerns/judge_common_concern.rb](/home/nukon/ws/aruaruarena/backend/app/services/concerns/judge_common_concern.rb)
+- [backend/app/services/create_cloud_front_invalidation_service.rb](/home/nukon/ws/aruaruarena/backend/app/services/create_cloud_front_invalidation_service.rb)
+- [backend/terraform/lambda.tf](/home/nukon/ws/aruaruarena/backend/terraform/lambda.tf)
+- [docs/deploy/frontend.md](/home/nukon/ws/aruaruarena/docs/deploy/frontend.md)
+
+## もし修正を入れるなら候補
+
+### 候補1: OGP画像欠損を検知しやすくする
+
+- `UploadOgpImageService` 失敗時のログを強化
+- `JudgeCommonConcern` 側でも warning 以上の運用シグナルを出す
+
+### 候補2: 欠損時 fallback を CDN 側で安全化
+
+- `/ogp/posts/*.png` 欠損時に `index.html` ではなく専用 fallback PNG を返す設計を検討
+
+### 候補3: 既存投稿を再生成
+
+- `scripts/regenerate_all_ogps.rb` を使って既存 `scored` 投稿の PNG を再作成
+
+## このセッションで変更したが、動的OGPの主因ではなさそうなもの
+
+- [backend/app/services/ogp_generator_service.rb](/home/nukon/ws/aruaruarena/backend/app/services/ogp_generator_service.rb)
+  - バッククォートをエスケープするよう変更
+- [backend/spec/services/ogp_generator_service_spec.rb](/home/nukon/ws/aruaruarena/backend/spec/services/ogp_generator_service_spec.rb)
+  - 上記の回帰テストを追加
+
+これは ImageMagick の安全性向上であり、「本番で画像が突然出なくなった」直接原因としては薄い。
+
+## 最後に
+
+次セッションの担当者は、まず「CloudFront の `/ogp/posts/<POST_ID>.png` が実際に何を返しているか」を確認すること。
+そこが `image/png` でない場合、Rails ではなく S3 / CloudFront / 事前生成のどこかに問題がある。

--- a/backend/app/services/create_cloud_front_invalidation_service.rb
+++ b/backend/app/services/create_cloud_front_invalidation_service.rb
@@ -14,11 +14,12 @@ class CreateCloudFrontInvalidationService
   end
 
   def execute
-    return false if distribution_id.empty?
-    return true if invalidation_succeeded?
+    if distribution_id.empty?
+      write_missing_distribution_log
+      return false
+    end
 
-    write_failure_log(last_response.code)
-    false
+    invalidation_succeeded?
   rescue StandardError => e
     write_exception_log(e)
     false
@@ -57,6 +58,13 @@ class CreateCloudFrontInvalidationService
   def write_success_log
     Rails.logger.info(
       "[CreateCloudFrontInvalidationService] CloudFront invalidation成功: post_id=#{@post_id}, path=#{@path}"
+    )
+  end
+
+  def write_missing_distribution_log
+    Rails.logger.warn(
+      '[CreateCloudFrontInvalidationService] CLOUDFRONT_DISTRIBUTION_ID が未設定のため invalidation をスキップ: ' \
+      "post_id=#{@post_id}, path=#{@path}"
     )
   end
 

--- a/backend/app/services/demo_posts_seed_data.rb
+++ b/backend/app/services/demo_posts_seed_data.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# ダミー投稿投入に使う固定データ
+module DemoPostsSeedData
+  PERSONAS = %w[hiroyuki dewi nakao].freeze
+  BASE_CREATED_AT = Time.zone.parse('2026-03-14 09:00:00 JST').to_i
+  SCORE_PATTERNS = {
+    'hiroyuki' => %i[originality brevity humor expression empathy],
+    'dewi' => %i[expression humor empathy originality brevity],
+    'nakao' => %i[humor empathy expression brevity originality]
+  }.freeze
+  COMMENT_TEMPLATES = {
+    'hiroyuki' => 'その場面、想像したらちょっと笑いました',
+    'dewi' => '観察が細かくて品よく面白いですわ',
+    'nakao' => '情景が浮かんで余韻までちゃんとありますね'
+  }.freeze
+  POSTS = [
+    { nickname: 'ルフィ', body: '会議前に急にやる気だけ海賊王級' },
+    { nickname: '孫悟空', body: '昼休みだけ食欲が戦闘モード' },
+    { nickname: 'ナルト', body: '既読つけた瞬間に返事を忘れるってばよ' },
+    { nickname: '炭治郎', body: '気まずい空気でもとりあえず謝る' },
+    { nickname: 'エレン', body: '締切直前だけ自由を奪われた顔になる' },
+    { nickname: 'ルルーシュ', body: '完璧な計画ほど寝坊で崩れる' },
+    { nickname: 'デク', body: 'メモだけ本気で行動が追いつかない' },
+    { nickname: '虎杖悠仁', body: 'ノリで引き受けて後から焦る' },
+    { nickname: '空条承太郎', body: '平静な顔で内心だけ大荒れ' },
+    { nickname: '坂田銀時', body: 'やる日は来ると言い続けて週末終わる' },
+    { nickname: '黒崎一護', body: '頼まれると結局断れずに残る' },
+    { nickname: '江戸川コナン', body: '違和感だけ先に見つけて説明できない' },
+    { nickname: '桜木花道', body: '根拠はないのに自信だけは満点' },
+    { nickname: 'ケンシロウ', body: '静かな怒りが顔にだけ出る' },
+    { nickname: '越前リョーマ', body: 'まだ本気出してない感だけうまい' },
+    { nickname: '緋村剣心', body: '丸く収めたあとで一人反省会する' },
+    { nickname: 'サイタマ', body: '全力出す前に用事が終わってる' },
+    { nickname: '両津勘吉', body: 'ひらめきは天才、詰めで全部こぼす' },
+    { nickname: '月野うさぎ', body: '朝だけ感情の起伏が魔法少女級' },
+    { nickname: '木之本桜', body: '片付けたはずの机が夕方また散らかる' }
+  ].freeze
+end

--- a/backend/app/services/ogp_meta_tag_service.rb
+++ b/backend/app/services/ogp_meta_tag_service.rb
@@ -3,6 +3,7 @@
 require 'erb'
 
 # OGPメタタグ生成サービス
+# rubocop:disable Metrics/ClassLength
 class OgpMetaTagService
   # 定数
   DEFAULT_OGP_IMAGE_PATH = '/ogp/default.png'
@@ -14,6 +15,8 @@ class OgpMetaTagService
   TWITTER_CARD = 'summary_large_image'
   IMAGE_WIDTH = 1200
   IMAGE_HEIGHT = 630
+  OGP_S3_PREFIX = 'ogp/posts'
+  S3_HEAD_TIMEOUT = 3
 
   # クローラー判定用キーワード
   CRAWLER_KEYWORDS = %w[
@@ -50,6 +53,7 @@ class OgpMetaTagService
 
     # 末尾のスラッシュを削除して正規化
     normalized_base_url = base_url.chomp('/')
+    image_url = ogp_image_url(post:, base_url: normalized_base_url)
 
     # HTMLテンプレートを構築
     # XSS対策: テキスト部分は必ず escape_html を通すこと
@@ -61,7 +65,7 @@ class OgpMetaTagService
         <meta property="og:title" content="#{escape_html(post.nickname || '')}さんのあるある投稿 | #{SITE_NAME}">
         <meta property="og:type" content="#{OG_TYPE}">
         <meta property="og:url" content="#{normalized_base_url}/posts/#{post.id}">
-        <meta property="og:image" content="#{normalized_base_url}/ogp/posts/#{post.id}.png">
+        <meta property="og:image" content="#{image_url}">
         <meta property="og:image:width" content="#{IMAGE_WIDTH}">
         <meta property="og:image:height" content="#{IMAGE_HEIGHT}">
         <meta property="og:description" content="#{escape_html(generate_description(body: post.body, average_score: post.average_score))}">
@@ -70,11 +74,20 @@ class OgpMetaTagService
         <meta name="twitter:card" content="#{TWITTER_CARD}">
         <meta name="twitter:title" content="#{escape_html(post.nickname || '')}さんのあるある投稿 | #{SITE_NAME}">
         <meta name="twitter:description" content="#{escape_html(generate_description(body: post.body, average_score: post.average_score))}">
-        <meta name="twitter:image" content="#{normalized_base_url}/ogp/posts/#{post.id}.png">
+        <meta name="twitter:image" content="#{image_url}">
       </head>
       <body></body>
       </html>
     HTML
+  end
+
+  def self.ogp_image_url(post:, base_url:)
+    normalized_base_url = base_url.chomp('/')
+    return generated_image_url(post:, base_url: normalized_base_url) if ogp_s3_bucket.blank?
+    return generated_image_url(post:, base_url: normalized_base_url) if uploaded_image_exists?(post:)
+
+    Rails.logger.warn("[OgpMetaTagService] 生成済みOGP画像が見つからないためデフォルト画像へフォールバック: post_id=#{post.id}")
+    default_image_url(base_url: normalized_base_url)
   end
 
   # 説明文（og:description）を生成する
@@ -115,6 +128,19 @@ class OgpMetaTagService
     ERB::Util.html_escape(text)
   end
 
+  def self.uploaded_image_exists?(post:)
+    build_s3_client.head_object(bucket: ogp_s3_bucket, key: object_key(post))
+    true
+  rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::NoSuchKey
+    false
+  rescue Aws::S3::Errors::ServiceError => e
+    Rails.logger.warn("[OgpMetaTagService] OGP画像存在確認に失敗: post_id=#{post.id} error=#{e.class} - #{e.message}")
+    false
+  rescue StandardError => e
+    Rails.logger.warn("[OgpMetaTagService] OGP画像存在確認で予期しない例外: post_id=#{post.id} error=#{e.class} - #{e.message}")
+    false
+  end
+
   # 文字列を指定した長さで省略する
   #
   # @param text [String] 対象文字列
@@ -133,4 +159,29 @@ class OgpMetaTagService
     truncated = text_str[0...(max_length - ellipsis_length)]
     "#{truncated}#{ELLIPSIS}"
   end
+
+  def self.default_image_url(base_url:)
+    "#{base_url}#{DEFAULT_OGP_IMAGE_PATH}"
+  end
+
+  def self.generated_image_url(post:, base_url:)
+    "#{base_url}/#{object_key(post)}"
+  end
+
+  def self.object_key(post)
+    "#{OGP_S3_PREFIX}/#{post.id}.png"
+  end
+
+  def self.ogp_s3_bucket
+    ENV.fetch('OGP_S3_BUCKET', '').strip
+  end
+
+  def self.build_s3_client
+    Aws::S3::Client.new(
+      region: ENV.fetch('AWS_REGION', 'ap-northeast-1'),
+      http_open_timeout: S3_HEAD_TIMEOUT,
+      http_read_timeout: S3_HEAD_TIMEOUT
+    )
+  end
 end
+# rubocop:enable Metrics/ClassLength

--- a/backend/app/services/ogp_meta_tag_service.rb
+++ b/backend/app/services/ogp_meta_tag_service.rb
@@ -130,18 +130,20 @@ class OgpMetaTagService
   end
 
   def self.uploaded_image_exists?(post:)
-    Rails.cache.fetch(uploaded_image_exists_cache_key(post), expires_in: UPLOADED_IMAGE_EXISTS_CACHE_TTL) do
-      build_s3_client.head_object(bucket: ogp_s3_bucket, key: object_key(post))
-      true
-    rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::NoSuchKey
-      false
-    rescue Aws::S3::Errors::ServiceError => e
-      Rails.logger.warn("[OgpMetaTagService] OGP画像存在確認に失敗: post_id=#{post.id} error=#{e.class} - #{e.message}")
-      false
-    rescue StandardError => e
-      Rails.logger.warn("[OgpMetaTagService] OGP画像存在確認で予期しない例外: post_id=#{post.id} error=#{e.class} - #{e.message}")
-      false
-    end
+    cache_key = uploaded_image_exists_cache_key(post)
+    return true if uploaded_image_exists_cache_store.read(cache_key)
+
+    build_s3_client.head_object(bucket: ogp_s3_bucket, key: object_key(post))
+    uploaded_image_exists_cache_store.write(cache_key, true, expires_in: UPLOADED_IMAGE_EXISTS_CACHE_TTL)
+    true
+  rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::NoSuchKey
+    false
+  rescue Aws::S3::Errors::ServiceError => e
+    Rails.logger.warn("[OgpMetaTagService] OGP画像存在確認に失敗: post_id=#{post.id} error=#{e.class} - #{e.message}")
+    false
+  rescue StandardError => e
+    Rails.logger.warn("[OgpMetaTagService] OGP画像存在確認で予期しない例外: post_id=#{post.id} error=#{e.class} - #{e.message}")
+    false
   end
 
   # 文字列を指定した長さで省略する
@@ -176,11 +178,21 @@ class OgpMetaTagService
   end
 
   def self.uploaded_image_exists_cache_key(post)
-    "ogp_meta_tag_service/uploaded_image_exists/#{object_key(post)}"
+    "ogp_meta_tag_service/uploaded_image_exists/#{ogp_s3_bucket}/#{object_key(post)}"
   end
 
   def self.ogp_s3_bucket
     ENV.fetch('OGP_S3_BUCKET', '').strip
+  end
+
+  def self.uploaded_image_exists_cache_store
+    return Rails.cache unless Rails.cache.is_a?(ActiveSupport::Cache::NullStore)
+
+    @uploaded_image_exists_cache_store ||= ActiveSupport::Cache::MemoryStore.new
+  end
+
+  def self.delete_uploaded_image_exists_cache!(post)
+    uploaded_image_exists_cache_store.delete(uploaded_image_exists_cache_key(post))
   end
 
   def self.build_s3_client

--- a/backend/app/services/ogp_meta_tag_service.rb
+++ b/backend/app/services/ogp_meta_tag_service.rb
@@ -17,6 +17,7 @@ class OgpMetaTagService
   IMAGE_HEIGHT = 630
   OGP_S3_PREFIX = 'ogp/posts'
   S3_HEAD_TIMEOUT = 3
+  UPLOADED_IMAGE_EXISTS_CACHE_TTL = 5.minutes
 
   # クローラー判定用キーワード
   CRAWLER_KEYWORDS = %w[
@@ -129,16 +130,18 @@ class OgpMetaTagService
   end
 
   def self.uploaded_image_exists?(post:)
-    build_s3_client.head_object(bucket: ogp_s3_bucket, key: object_key(post))
-    true
-  rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::NoSuchKey
-    false
-  rescue Aws::S3::Errors::ServiceError => e
-    Rails.logger.warn("[OgpMetaTagService] OGP画像存在確認に失敗: post_id=#{post.id} error=#{e.class} - #{e.message}")
-    false
-  rescue StandardError => e
-    Rails.logger.warn("[OgpMetaTagService] OGP画像存在確認で予期しない例外: post_id=#{post.id} error=#{e.class} - #{e.message}")
-    false
+    Rails.cache.fetch(uploaded_image_exists_cache_key(post), expires_in: UPLOADED_IMAGE_EXISTS_CACHE_TTL) do
+      build_s3_client.head_object(bucket: ogp_s3_bucket, key: object_key(post))
+      true
+    rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::NoSuchKey
+      false
+    rescue Aws::S3::Errors::ServiceError => e
+      Rails.logger.warn("[OgpMetaTagService] OGP画像存在確認に失敗: post_id=#{post.id} error=#{e.class} - #{e.message}")
+      false
+    rescue StandardError => e
+      Rails.logger.warn("[OgpMetaTagService] OGP画像存在確認で予期しない例外: post_id=#{post.id} error=#{e.class} - #{e.message}")
+      false
+    end
   end
 
   # 文字列を指定した長さで省略する
@@ -170,6 +173,10 @@ class OgpMetaTagService
 
   def self.object_key(post)
     "#{OGP_S3_PREFIX}/#{post.id}.png"
+  end
+
+  def self.uploaded_image_exists_cache_key(post)
+    "ogp_meta_tag_service/uploaded_image_exists/#{object_key(post)}"
   end
 
   def self.ogp_s3_bucket

--- a/backend/app/services/ogp_meta_tag_service.rb
+++ b/backend/app/services/ogp_meta_tag_service.rb
@@ -191,6 +191,14 @@ class OgpMetaTagService
     @uploaded_image_exists_cache_store ||= ActiveSupport::Cache::MemoryStore.new
   end
 
+  def self.clear_uploaded_image_exists_cache!
+    cache_store = @uploaded_image_exists_cache_store
+    return unless cache_store.respond_to?(:clear)
+
+    cache_store.clear
+    @uploaded_image_exists_cache_store = nil
+  end
+
   def self.delete_uploaded_image_exists_cache!(post)
     uploaded_image_exists_cache_store.delete(uploaded_image_exists_cache_key(post))
   end

--- a/backend/app/services/reset_demo_posts_service.rb
+++ b/backend/app/services/reset_demo_posts_service.rb
@@ -31,7 +31,7 @@ class ResetDemoPostsService
   end
 
   def build_judgments!(post:, index:)
-    totals = judgment_totals(post.average_score.to_f, index)
+    totals = judgment_totals(demo_total_sum(index), index)
 
     DemoPostsSeedData::PERSONAS.each_with_index do |persona, persona_index|
       Judgment.create!(judgment_attributes(post:, persona:, persona_index:, total_score: totals[persona_index]))
@@ -39,12 +39,14 @@ class ResetDemoPostsService
   end
 
   def demo_average_score(index)
-    step = 10.0 / (DemoPostsSeedData::POSTS.size - 1)
-    (75.0 - (index * step)).round(1)
+    (demo_total_sum(index) / DemoPostsSeedData::PERSONAS.count.to_f).round(1)
   end
 
-  def judgment_totals(average_score, index)
-    total_sum = (average_score * DemoPostsSeedData::PERSONAS.count).round
+  def demo_total_sum(index)
+    225 - index
+  end
+
+  def judgment_totals(total_sum, index)
     base = total_sum / 3
     totals = [base, base, base]
 

--- a/backend/app/services/reset_demo_posts_service.rb
+++ b/backend/app/services/reset_demo_posts_service.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+# ダミー投稿の初期化と再投入を行うサービス
+class ResetDemoPostsService
+  class << self
+    delegate :call, to: :new
+  end
+
+  def call
+    clear_tables!
+
+    DemoPostsSeedData::POSTS.each_with_index.map do |entry, index|
+      build_demo_post!(entry:, index:)
+    end
+  end
+
+  private
+
+  def clear_tables!
+    [Judgment, Post, RateLimit, DuplicateCheck].each(&:delete_all)
+  end
+
+  def build_demo_post!(entry:, index:)
+    post_id = SecureRandom.uuid
+    post = Post.new(post_attributes(entry:, index:, post_id:))
+    post.score_key = post.generate_score_key
+    post.save!
+
+    build_judgments!(post:, index:)
+    post
+  end
+
+  def build_judgments!(post:, index:)
+    totals = judgment_totals(post.average_score.to_f, index)
+
+    DemoPostsSeedData::PERSONAS.each_with_index do |persona, persona_index|
+      Judgment.create!(judgment_attributes(post:, persona:, persona_index:, total_score: totals[persona_index]))
+    end
+  end
+
+  def demo_average_score(index)
+    ((225 - (index * 2)) / 3.0).round(1)
+  end
+
+  def judgment_totals(average_score, index)
+    total_sum = (average_score * DemoPostsSeedData::PERSONAS.count).round
+    base = total_sum / 3
+    totals = [base, base, base]
+
+    (total_sum - (base * 3)).times do |offset|
+      totals[judgment_bonus_order(index)[offset]] += 1
+    end
+
+    totals
+  end
+
+  def score_breakdown(total_score, persona)
+    scores = Judgment::SCORE_FIELDS.index_with { 13 }
+    remaining = total_score - (Judgment::SCORE_FIELDS.count * 13)
+
+    DemoPostsSeedData::SCORE_PATTERNS.fetch(persona).cycle do |field|
+      break if remaining.zero?
+
+      next if scores[field] >= Judgment::MAX_SCORE_PER_ITEM
+
+      scores[field] += 1
+      remaining -= 1
+    end
+
+    scores
+  end
+
+  def post_attributes(entry:, index:, post_id:)
+    {
+      id: post_id,
+      nickname: entry[:nickname],
+      body: entry[:body],
+      status: Post::STATUS_SCORED,
+      average_score: demo_average_score(index),
+      judges_count: DemoPostsSeedData::PERSONAS.count,
+      created_at: (DemoPostsSeedData::BASE_CREATED_AT + (index * 60)).to_s
+    }
+  end
+
+  def judgment_attributes(post:, persona:, persona_index:, total_score:)
+    {
+      post_id: post.id,
+      persona: persona,
+      id: SecureRandom.uuid,
+      succeeded: true,
+      **score_breakdown(total_score, persona),
+      total_score: total_score,
+      comment: DemoPostsSeedData::COMMENT_TEMPLATES.fetch(persona),
+      judged_at: (post.created_at.to_i + persona_index + 1).to_s
+    }
+  end
+
+  def judgment_bonus_order(index)
+    case index % 3
+    when 0 then [2, 0, 1]
+    when 1 then [0, 2, 1]
+    else [1, 2, 0]
+    end
+  end
+end

--- a/backend/app/services/reset_demo_posts_service.rb
+++ b/backend/app/services/reset_demo_posts_service.rb
@@ -39,7 +39,8 @@ class ResetDemoPostsService
   end
 
   def demo_average_score(index)
-    ((225 - (index * 2)) / 3.0).round(1)
+    step = 10.0 / (DemoPostsSeedData::POSTS.size - 1)
+    (75.0 - (index * step)).round(1)
   end
 
   def judgment_totals(average_score, index)

--- a/backend/app/services/upload_ogp_image_service.rb
+++ b/backend/app/services/upload_ogp_image_service.rb
@@ -100,6 +100,7 @@ class UploadOgpImageService
       content_type: 'image/png',
       cache_control: CACHE_CONTROL
     )
+    OgpMetaTagService.delete_uploaded_image_exists_cache!(@post)
   end
 
   def generate_ogp_image

--- a/backend/lib/tasks/dynamodb.rake
+++ b/backend/lib/tasks/dynamodb.rake
@@ -122,6 +122,8 @@ namespace :dynamodb do
     if $stdin.tty?
       print '投稿データを初期化します。よろしいですか？ (yes/no): '
       return unless $stdin.gets.chomp == 'yes'
+    elsif ENV['FORCE_RESET_DEMO_POSTS'] != 'yes'
+      abort '非対話環境では FORCE_RESET_DEMO_POSTS=yes を指定してください'
     end
 
     puts '投稿データを初期化してダミーデータを作成中...'

--- a/backend/lib/tasks/dynamodb.rake
+++ b/backend/lib/tasks/dynamodb.rake
@@ -116,4 +116,24 @@ namespace :dynamodb do
 
     puts "✅ #{posts.count} 件の投稿を更新しました"
   end
+
+  desc '投稿関連データを初期化してダミー投稿20件を再投入'
+  task reset_demo_posts: :environment do
+    if $stdin.tty?
+      print '投稿データを初期化します。よろしいですか？ (yes/no): '
+      return unless $stdin.gets.chomp == 'yes'
+    end
+
+    puts '投稿データを初期化してダミーデータを作成中...'
+
+    posts = ResetDemoPostsService.call
+
+    puts "✅ #{posts.count} 件のダミー投稿を作成しました"
+    if posts.any?
+      puts "   1位: #{posts.first.nickname} #{posts.first.average_score}点"
+      puts "   #{posts.count}位: #{posts.last.nickname} #{posts.last.average_score}点"
+    else
+      puts '   投稿は作成されませんでした'
+    end
+  end
 end

--- a/backend/lib/tasks/dynamodb.rake
+++ b/backend/lib/tasks/dynamodb.rake
@@ -121,7 +121,8 @@ namespace :dynamodb do
   task reset_demo_posts: :environment do
     if $stdin.tty?
       print '投稿データを初期化します。よろしいですか？ (yes/no): '
-      return unless $stdin.gets.chomp == 'yes'
+      answer = $stdin.gets&.strip&.downcase
+      return unless answer == 'yes'
     elsif ENV['FORCE_RESET_DEMO_POSTS'] != 'yes'
       abort '非対話環境では FORCE_RESET_DEMO_POSTS=yes を指定してください'
     end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -3,13 +3,12 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
+require_relative 'support/dynamodb_constants'
 
 # テスト実行時に古いDynamoDB Localの既定ポート(8000)が残っていても、
 # 現在のテスト環境で利用する8002へ統一する。
-legacy_dynamodb_endpoints = ['http://127.0.0.1:8000', 'http://localhost:8000'].freeze
-if ENV['RAILS_ENV'] == 'test' &&
-   (ENV['DYNAMODB_ENDPOINT'].to_s.empty? || legacy_dynamodb_endpoints.include?(ENV.fetch('DYNAMODB_ENDPOINT', nil)))
-  ENV['DYNAMODB_ENDPOINT'] = 'http://127.0.0.1:8002'
+if ENV['RAILS_ENV'] == 'test'
+  ENV['DYNAMODB_ENDPOINT'] = DynamoDBConstants.normalized_endpoint(ENV.fetch('DYNAMODB_ENDPOINT', nil))
 end
 
 # Prevent database truncation if the environment is production

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -4,6 +4,14 @@
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 
+# テスト実行時に古いDynamoDB Localの既定ポート(8000)が残っていても、
+# 現在のテスト環境で利用する8002へ統一する。
+legacy_dynamodb_endpoints = ['http://127.0.0.1:8000', 'http://localhost:8000'].freeze
+if ENV['RAILS_ENV'] == 'test' &&
+   (ENV['DYNAMODB_ENDPOINT'].to_s.empty? || legacy_dynamodb_endpoints.include?(ENV.fetch('DYNAMODB_ENDPOINT', nil)))
+  ENV['DYNAMODB_ENDPOINT'] = 'http://127.0.0.1:8002'
+end
+
 # Prevent database truncation if the environment is production
 # Rails環境を読み込んだ後にチェックする
 

--- a/backend/spec/services/create_cloud_front_invalidation_service_spec.rb
+++ b/backend/spec/services/create_cloud_front_invalidation_service_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe CreateCloudFrontInvalidationService, type: :service, dynamodb: fa
     expect(described_class.call(path: '/ogp/posts/post-id.png', post_id: 'post-id')).to be false
   end
 
+  it 'distribution id 未設定時は警告ログを出すこと' do
+    allow(Rails.logger).to receive(:warn)
+
+    expect(described_class.call(path: '/ogp/posts/post-id.png', post_id: 'post-id')).to be false
+    expect(Rails.logger).to have_received(:warn).with(/CLOUDFRONT_DISTRIBUTION_ID が未設定のため invalidation をスキップ/)
+  end
+
   it 'distribution id が設定されている場合は CloudFront invalidation を行うこと' do
     ENV['CLOUDFRONT_DISTRIBUTION_ID'] = 'DIST123'
     allow(Aws::CloudFront::Client).to receive(:new).and_return(cloudfront_client)

--- a/backend/spec/services/ogp_meta_tag_service_spec.rb
+++ b/backend/spec/services/ogp_meta_tag_service_spec.rb
@@ -194,11 +194,13 @@ RSpec.describe OgpMetaTagService, type: :service do
       original_ogp_s3_bucket = ENV.fetch('OGP_S3_BUCKET', nil)
       original_aws_region = ENV.fetch('AWS_REGION', nil)
       Rails.cache.clear
+      described_class.clear_uploaded_image_exists_cache!
       example.run
     ensure
       original_ogp_s3_bucket.nil? ? ENV.delete('OGP_S3_BUCKET') : ENV['OGP_S3_BUCKET'] = original_ogp_s3_bucket
       original_aws_region.nil? ? ENV.delete('AWS_REGION') : ENV['AWS_REGION'] = original_aws_region
       Rails.cache.clear
+      described_class.clear_uploaded_image_exists_cache!
     end
 
     context '正常系 (Happy Path)' do
@@ -489,6 +491,24 @@ RSpec.describe OgpMetaTagService, type: :service do
         # 重複スラッシュがないことを確認 (http://...//posts/...)
         expect(html).not_to include('//posts/')
       end
+    end
+  end
+
+  describe '.clear_uploaded_image_exists_cache!' do
+    after do
+      described_class.instance_variable_set(:@uploaded_image_exists_cache_store, nil)
+    end
+
+    it 'フォールバック用MemoryStoreをクリアして再生成可能な状態へ戻すこと' do
+      cache_key = 'ogp_meta_tag_service/test'
+      initial_store = ActiveSupport::Cache::MemoryStore.new
+      described_class.instance_variable_set(:@uploaded_image_exists_cache_store, initial_store)
+      initial_store.write(cache_key, true)
+
+      described_class.clear_uploaded_image_exists_cache!
+
+      expect(initial_store.read(cache_key)).to be_nil
+      expect(described_class.instance_variable_get(:@uploaded_image_exists_cache_store)).to be_nil
     end
   end
 

--- a/backend/spec/services/ogp_meta_tag_service_spec.rb
+++ b/backend/spec/services/ogp_meta_tag_service_spec.rb
@@ -190,9 +190,15 @@ RSpec.describe OgpMetaTagService, type: :service do
     end
     let(:base_url) { 'https://example.com' }
 
-    after do
-      ENV.delete('OGP_S3_BUCKET')
-      ENV.delete('AWS_REGION')
+    around do |example|
+      original_ogp_s3_bucket = ENV.fetch('OGP_S3_BUCKET', nil)
+      original_aws_region = ENV.fetch('AWS_REGION', nil)
+      Rails.cache.clear
+      example.run
+    ensure
+      original_ogp_s3_bucket.nil? ? ENV.delete('OGP_S3_BUCKET') : ENV['OGP_S3_BUCKET'] = original_ogp_s3_bucket
+      original_aws_region.nil? ? ENV.delete('AWS_REGION') : ENV['AWS_REGION'] = original_aws_region
+      Rails.cache.clear
     end
 
     context '正常系 (Happy Path)' do
@@ -318,6 +324,18 @@ RSpec.describe OgpMetaTagService, type: :service do
         expect(head_request.dig(:params, :bucket)).to eq('test-ogp-bucket')
         expect(head_request.dig(:params, :key)).to eq("ogp/posts/#{post.id}.png")
         expect(html).to include("property=\"og:image\" content=\"#{base_url}/ogp/posts/#{post.id}.png\"")
+      end
+
+      it '同じ投稿の画像存在確認結果を短時間キャッシュすること' do
+        ENV['OGP_S3_BUCKET'] = 'test-ogp-bucket'
+        s3_client = Aws::S3::Client.new(region: 'ap-northeast-1', stub_responses: true)
+        allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
+
+        2.times { described_class.generate_html(post:, base_url:) }
+
+        head_requests = s3_client.api_requests.select { |request| request[:operation_name] == :head_object }
+
+        expect(head_requests.size).to eq(1)
       end
 
       it 'S3に画像が存在しない場合はデフォルト画像へフォールバックすること' do

--- a/backend/spec/services/ogp_meta_tag_service_spec.rb
+++ b/backend/spec/services/ogp_meta_tag_service_spec.rb
@@ -338,6 +338,19 @@ RSpec.describe OgpMetaTagService, type: :service do
         expect(head_requests.size).to eq(1)
       end
 
+      it 'S3に画像が存在しない場合はfalseをキャッシュしないこと' do
+        ENV['OGP_S3_BUCKET'] = 'test-ogp-bucket'
+        s3_client = Aws::S3::Client.new(region: 'ap-northeast-1', stub_responses: true)
+        s3_client.stub_responses(:head_object, 'NotFound')
+        allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
+
+        2.times { described_class.generate_html(post:, base_url:) }
+
+        head_requests = s3_client.api_requests.select { |request| request[:operation_name] == :head_object }
+
+        expect(head_requests.size).to eq(2)
+      end
+
       it 'S3に画像が存在しない場合はデフォルト画像へフォールバックすること' do
         ENV['OGP_S3_BUCKET'] = 'test-ogp-bucket'
         s3_client = Aws::S3::Client.new(region: 'ap-northeast-1', stub_responses: true)

--- a/backend/spec/services/ogp_meta_tag_service_spec.rb
+++ b/backend/spec/services/ogp_meta_tag_service_spec.rb
@@ -190,6 +190,11 @@ RSpec.describe OgpMetaTagService, type: :service do
     end
     let(:base_url) { 'https://example.com' }
 
+    after do
+      ENV.delete('OGP_S3_BUCKET')
+      ENV.delete('AWS_REGION')
+    end
+
     context '正常系 (Happy Path)' do
       it '正しいOGPタグが含まれるHTMLを返すこと' do
         # 何を検証するか: 必要なOGPタグがすべて含まれること
@@ -292,6 +297,52 @@ RSpec.describe OgpMetaTagService, type: :service do
         html = described_class.generate_html(post:, base_url:)
 
         expect(html).to include("name=\"twitter:image\" content=\"#{base_url}/ogp/posts/#{post.id}.png\"")
+      end
+
+      it 'OGP_S3_BUCKET未設定時はS3確認を行わず投稿画像URLを使うこと' do
+        expect(Aws::S3::Client).not_to receive(:new)
+
+        html = described_class.generate_html(post:, base_url:)
+
+        expect(html).to include("property=\"og:image\" content=\"#{base_url}/ogp/posts/#{post.id}.png\"")
+      end
+
+      it 'S3に画像が存在する場合は投稿画像URLを使うこと' do
+        ENV['OGP_S3_BUCKET'] = 'test-ogp-bucket'
+        s3_client = Aws::S3::Client.new(region: 'ap-northeast-1', stub_responses: true)
+        allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
+
+        html = described_class.generate_html(post:, base_url:)
+
+        head_request = s3_client.api_requests.find { |request| request[:operation_name] == :head_object }
+        expect(head_request.dig(:params, :bucket)).to eq('test-ogp-bucket')
+        expect(head_request.dig(:params, :key)).to eq("ogp/posts/#{post.id}.png")
+        expect(html).to include("property=\"og:image\" content=\"#{base_url}/ogp/posts/#{post.id}.png\"")
+      end
+
+      it 'S3に画像が存在しない場合はデフォルト画像へフォールバックすること' do
+        ENV['OGP_S3_BUCKET'] = 'test-ogp-bucket'
+        s3_client = Aws::S3::Client.new(region: 'ap-northeast-1', stub_responses: true)
+        s3_client.stub_responses(:head_object, 'NotFound')
+        allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
+        allow(Rails.logger).to receive(:warn)
+
+        html = described_class.generate_html(post:, base_url:)
+
+        expect(html).to include("property=\"og:image\" content=\"#{base_url}/ogp/default.png\"")
+        expect(html).to include("name=\"twitter:image\" content=\"#{base_url}/ogp/default.png\"")
+        expect(Rails.logger).to have_received(:warn).with(/生成済みOGP画像が見つからないためデフォルト画像へフォールバック/)
+      end
+
+      it 'S3確認で例外が発生した場合もデフォルト画像へフォールバックすること' do
+        ENV['OGP_S3_BUCKET'] = 'test-ogp-bucket'
+        allow(Aws::S3::Client).to receive(:new).and_raise(StandardError, 'timeout')
+        allow(Rails.logger).to receive(:warn)
+
+        html = described_class.generate_html(post:, base_url:)
+
+        expect(html).to include("property=\"og:image\" content=\"#{base_url}/ogp/default.png\"")
+        expect(Rails.logger).to have_received(:warn).with(/OGP画像存在確認で予期しない例外/)
       end
     end
 

--- a/backend/spec/services/reset_demo_posts_service_spec.rb
+++ b/backend/spec/services/reset_demo_posts_service_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ResetDemoPostsService, type: :service do
+  describe '.call' do
+    it '投稿関連データを初期化して20件のダミー投稿を作成すること' do
+      create(:post, :scored, nickname: '既存投稿', body: '古い投稿です', average_score: 80.0)
+      create(:judgment, post_id: Post.first.id, persona: 'hiroyuki')
+      RateLimit.create!(identifier: 'nick#old', expires_at: Time.current.to_i + 300)
+      DuplicateCheck.create!(body_hash: 'old_hash', post_id: SecureRandom.uuid, expires_at: Time.current.to_i + 3600)
+
+      posts = described_class.call
+
+      expect(posts.count).to eq(20)
+      expect(Post.count).to eq(20)
+      expect(Judgment.count).to eq(60)
+      expect(RateLimit.count).to eq(0)
+      expect(DuplicateCheck.count).to eq(0)
+      expect(Post.all.map(&:nickname)).not_to include('既存投稿')
+    end
+
+    it 'ランキング順が1位から20位まで一意に決まること' do
+      described_class.call
+
+      rankings = Post.top_rankings(20)
+      scores = rankings.map { |post| post.average_score.to_f }
+      ranks = rankings.map(&:calculate_rank)
+
+      expect(rankings.count).to eq(20)
+      expect(scores).to all(be_between(65.0, 75.0))
+      expect(scores).to eq(scores.sort.reverse)
+      expect(ranks).to eq((1..20).to_a)
+    end
+
+    it '各投稿に3人分の成功Judgmentを紐づけて平均点と整合すること' do
+      posts = described_class.call
+
+      posts.each do |post|
+        judgments = Judgment.where(post_id: post.id).to_a.sort_by(&:persona)
+        average_score = (judgments.sum(&:total_score) / 3.0).round(1)
+
+        aggregate_failures do
+          expect(post.status).to eq(Post::STATUS_SCORED)
+          expect(post.judges_count).to eq(3)
+          expect(post.score_key).to be_present
+          expect(judgments.count).to eq(3)
+          expect(judgments.map(&:persona)).to match_array(%w[dewi hiroyuki nakao])
+          expect(judgments).to all(have_attributes(succeeded: true))
+          expect(average_score).to eq(post.average_score.to_f)
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/services/upload_ogp_image_service_spec.rb
+++ b/backend/spec/services/upload_ogp_image_service_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe UploadOgpImageService, type: :service, dynamodb: false do
   end
 
   it '生成したOGP画像をS3へ保存すること' do
+    allow(OgpMetaTagService).to receive(:delete_uploaded_image_exists_cache!).with(post)
+
     expect(described_class.call('post-id', s3_client:)).to be true
 
     request = s3_client.api_requests.find { |api_request| api_request[:operation_name] == :put_object }
@@ -70,6 +72,7 @@ RSpec.describe UploadOgpImageService, type: :service, dynamodb: false do
       bucket_name: 'test-ogp-bucket',
       object_key: 'ogp/posts/post-id.png'
     )
+    expect(OgpMetaTagService).to have_received(:delete_uploaded_image_exists_cache!).with(post)
   end
 
   it 'invalidation に失敗しても S3保存成功なら true を返すこと' do

--- a/backend/spec/support/dynamodb_constants.rb
+++ b/backend/spec/support/dynamodb_constants.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module DynamoDBConstants
+  LEGACY_ENDPOINTS = ['http://127.0.0.1:8000', 'http://localhost:8000'].freeze
+  TEST_ENDPOINT = 'http://127.0.0.1:8002'
+
+  def self.normalized_endpoint(endpoint)
+    return TEST_ENDPOINT if endpoint.to_s.empty?
+    return TEST_ENDPOINT if LEGACY_ENDPOINTS.include?(endpoint)
+
+    endpoint
+  end
+end

--- a/backend/spec/support/dynamodb_test_helpers.rb
+++ b/backend/spec/support/dynamodb_test_helpers.rb
@@ -78,7 +78,7 @@ module DynamoDBTestHelpers
   private
 
   def cleanup_model_table!(model)
-    endpoint = ENV.fetch('DYNAMODB_ENDPOINT', nil)
+    endpoint = normalized_dynamodb_endpoint
     Dynamoid.config.endpoint = endpoint if endpoint.present? && Dynamoid.config.endpoint != endpoint
 
     delete_timeout = model == Post ? POST_CLEANUP_DELETE_TIMEOUT : CLEANUP_DELETE_TIMEOUT
@@ -136,5 +136,12 @@ module DynamoDBTestHelpers
           .count
     end
     "base=#{base_count}件, ranking_index=#{ranking_count}件が残存"
+  end
+
+  def normalized_dynamodb_endpoint
+    endpoint = ENV.fetch('DYNAMODB_ENDPOINT', nil)
+    return 'http://127.0.0.1:8002' if ['http://127.0.0.1:8000', 'http://localhost:8000'].include?(endpoint)
+
+    endpoint
   end
 end

--- a/backend/spec/support/dynamodb_test_helpers.rb
+++ b/backend/spec/support/dynamodb_test_helpers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'timeout'
+require_relative 'dynamodb_constants'
 
 module DynamoDBTestHelpers
   include DynamoDBJudgmentHelpers
@@ -139,9 +140,6 @@ module DynamoDBTestHelpers
   end
 
   def normalized_dynamodb_endpoint
-    endpoint = ENV.fetch('DYNAMODB_ENDPOINT', nil)
-    return 'http://127.0.0.1:8002' if ['http://127.0.0.1:8000', 'http://localhost:8000'].include?(endpoint)
-
-    endpoint
+    DynamoDBConstants.normalized_endpoint(ENV.fetch('DYNAMODB_ENDPOINT', nil))
   end
 end

--- a/backend/spec/support/dynamoid.rb
+++ b/backend/spec/support/dynamoid.rb
@@ -4,6 +4,7 @@
 RSpec.configure do |config|
   config.before(:suite) do
     endpoint = ENV['DYNAMODB_ENDPOINT'].presence || 'http://127.0.0.1:8002'
+    endpoint = 'http://127.0.0.1:8002' if ['http://127.0.0.1:8000', 'http://localhost:8000'].include?(endpoint)
     ENV['DYNAMODB_ENDPOINT'] = endpoint
 
     # テスト用DynamoDB設定

--- a/backend/spec/support/dynamoid.rb
+++ b/backend/spec/support/dynamoid.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
+require_relative 'dynamodb_constants'
+
 # DynamoDB Localの設定
 RSpec.configure do |config|
   config.before(:suite) do
-    endpoint = ENV['DYNAMODB_ENDPOINT'].presence || 'http://127.0.0.1:8002'
-    endpoint = 'http://127.0.0.1:8002' if ['http://127.0.0.1:8000', 'http://localhost:8000'].include?(endpoint)
+    endpoint = DynamoDBConstants.normalized_endpoint(ENV.fetch('DYNAMODB_ENDPOINT', nil))
     ENV['DYNAMODB_ENDPOINT'] = endpoint
 
     # テスト用DynamoDB設定

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -984,14 +984,10 @@ function App() {
         // failed応答は結果画面へ直接遷移し、ポーリングは中断する。
         setJudgingErrorMessage('')
         clearJudgingPolling()
+        clearMinimumJudgingDuration(false)
         setIsJudgingPollingReady(false)
-        void (async () => {
-          const canProceed = await waitForMinimumJudgingDuration()
-          if (!canProceed) return
-          clearMinimumJudgingDuration(false)
-          setPendingFormData(null)
-          enterResultView(response.id, null, { source: 'judging' })
-        })()
+        setPendingFormData(null)
+        enterResultView(response.id, null, { source: 'judging' })
         return
       }
 
@@ -1005,7 +1001,6 @@ function App() {
       syncJudgingPath,
       syncMyPostIds,
       enterJudgingMode,
-      waitForMinimumJudgingDuration,
     ]
   )
 
@@ -1906,9 +1901,7 @@ function App() {
         className="game-show-stage relative min-h-screen overflow-hidden px-6 pb-6"
         style={{ isolation: 'isolate', paddingBottom: `${footerReservedSpace}px` }}
       >
-        {viewMode === 'judging' && !judgingErrorMessage && (
-          <JudgingIndicator />
-        )}
+        {viewMode === 'judging' && !judgingErrorMessage && <JudgingIndicator />}
         {viewMode === 'judging' && !judgingErrorMessage && judgingTransientErrorCount > 0 && (
           <div className="pointer-events-none fixed left-1/2 top-5 z-[125] -translate-x-1/2">
             <p
@@ -2121,15 +2114,15 @@ function App() {
                             const post = myPostDetails[postId]
                             const isLoading = loadingMyPostIds.includes(postId)
                             const errorMessage = myPostDetailErrors[postId]
-                            const myPostButtonLabel = post
-                              ? `${post.body}、${MY_POST_STATUS_LABELS[post.status]}、投稿詳細を開く`
-                              : `投稿ID ${postId} の投稿詳細を開く`
-
                             return (
                               <li key={postId} data-testid="my-post-id-item">
                                 <button
                                   type="button"
-                                  aria-label={myPostButtonLabel}
+                                  aria-label={
+                                    post
+                                      ? `${post.body}、${MY_POST_STATUS_LABELS[post.status]}、投稿詳細を開く`
+                                      : `投稿ID ${postId} の投稿詳細を開く`
+                                  }
                                   aria-describedby={`my-post-meta-${postId}`}
                                   className="w-full rounded-[1.4rem] border border-white/12 bg-[radial-gradient(circle_at_top_left,rgba(255,214,120,0.16),transparent_35%),linear-gradient(180deg,rgba(20,28,45,0.92),rgba(9,14,25,0.96))] p-4 text-left transition hover:border-amber-200/35 hover:shadow-[0_18px_38px_rgba(8,15,30,0.32)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/70"
                                   onClick={() => handleMyPostClick(postId)}

--- a/frontend/src/features/judging/components/JudgingIndicator.tsx
+++ b/frontend/src/features/judging/components/JudgingIndicator.tsx
@@ -33,6 +33,7 @@ export function JudgingIndicator() {
   return (
     <div
       data-testid="judging-screen"
+      role="status"
       aria-label="審査中"
       aria-live="polite"
       className="pointer-events-none fixed inset-x-0 top-20 z-40 flex items-center justify-center px-4 sm:top-24"

--- a/frontend/src/features/judging/components/JudgingIndicator.tsx
+++ b/frontend/src/features/judging/components/JudgingIndicator.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useState } from 'react'
+import { useReducedMotion } from '../../../shared/hooks/useReducedMotion'
 
 const PHRASES = [
   '投稿を受け付けました ✨',
@@ -10,14 +11,20 @@ const PHRASES = [
 
 const PHRASE_DURATION_MS = 1980
 
-interface JudgingIndicatorProps {}
-
-export function JudgingIndicator({}: JudgingIndicatorProps = {}) {
+export function JudgingIndicator() {
   const [phaseIndex, setPhaseIndex] = useState(0)
+  const prefersReducedMotion = useReducedMotion()
+  const animationProps = prefersReducedMotion
+    ? {}
+    : {
+        initial: { opacity: 0, y: 15 },
+        animate: { opacity: 1, y: 0 },
+        exit: { opacity: 0, y: -15 },
+      }
 
   useEffect(() => {
     const timer = setInterval(() => {
-      setPhaseIndex((prev) => (prev + 1) % PHRASES.length)
+      setPhaseIndex((prev) => Math.min(prev + 1, PHRASES.length - 1))
     }, PHRASE_DURATION_MS)
 
     return () => clearInterval(timer)
@@ -25,19 +32,19 @@ export function JudgingIndicator({}: JudgingIndicatorProps = {}) {
 
   return (
     <div
+      data-testid="judging-screen"
+      aria-label="審査中"
+      aria-live="polite"
       className="pointer-events-none fixed inset-x-0 top-20 z-40 flex items-center justify-center px-4 sm:top-24"
-      aria-hidden="true"
     >
       <AnimatePresence mode="wait">
         <motion.div
           key={phaseIndex}
-          initial={{ opacity: 0, y: 15 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -15 }}
+          {...animationProps}
           transition={{ duration: 0.6, ease: 'easeInOut' }}
-          className="glass-panel min-w-[240px] max-w-sm rounded-[2rem] border border-amber-200/40 bg-gradient-to-r from-amber-500/10 via-yellow-300/10 to-amber-500/10 px-6 py-3 text-center shadow-[0_0_24px_rgba(251,191,36,0.15)]"
+          className="glass-panel min-w-[240px] max-w-sm rounded-[2rem] border border-amber-200/55 bg-gradient-to-r from-slate-950/42 via-amber-950/24 to-slate-950/42 px-6 py-3 text-center shadow-[0_0_24px_rgba(251,191,36,0.18)]"
         >
-          <p className="gold-text text-base font-bold tracking-wider sm:text-lg">
+          <p className="gold-text inline-flex rounded-full bg-slate-950/35 px-4 py-1 text-base font-black tracking-[0.18em] text-amber-50 [text-shadow:0_1px_0_rgba(120,72,0,0.95),0_0_10px_rgba(255,217,120,0.55),0_0_22px_rgba(255,169,67,0.35)] sm:text-lg">
             {PHRASES[phaseIndex]}
           </p>
         </motion.div>

--- a/frontend/src/features/judging/components/JudgingIndicator.tsx
+++ b/frontend/src/features/judging/components/JudgingIndicator.tsx
@@ -24,7 +24,14 @@ export function JudgingIndicator() {
 
   useEffect(() => {
     const timer = setInterval(() => {
-      setPhaseIndex((prev) => Math.min(prev + 1, PHRASES.length - 1))
+      setPhaseIndex((prev) => {
+        if (prev >= PHRASES.length - 1) {
+          clearInterval(timer)
+          return prev
+        }
+
+        return prev + 1
+      })
     }, PHRASE_DURATION_MS)
 
     return () => clearInterval(timer)

--- a/frontend/src/features/judging/components/__tests__/JudgingIndicator.test.tsx
+++ b/frontend/src/features/judging/components/__tests__/JudgingIndicator.test.tsx
@@ -1,22 +1,32 @@
 import { act, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { JudgingIndicator } from '../JudgingIndicator'
+
+const useReducedMotionMock = vi.fn(() => false)
+
+vi.mock('../../../../shared/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => useReducedMotionMock(),
+}))
 
 vi.mock('framer-motion', async () => {
   const actual = await vi.importActual<typeof import('framer-motion')>('framer-motion')
   return {
     ...actual,
-    AnimatePresence: ({ children }: any) => <>{children}</>,
+    AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
   }
 })
 
 describe('JudgingIndicator', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    useReducedMotionMock.mockReturnValue(false)
   })
 
   afterEach(() => {
-    vi.runOnlyPendingTimers()
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
     vi.useRealTimers()
   })
 
@@ -35,10 +45,43 @@ describe('JudgingIndicator', () => {
     })
     expect(screen.getByText('審査員が評価中...')).toBeInTheDocument()
 
-    // さらに2500ms進める
+    // さらに1980ms進める
     act(() => {
       vi.advanceTimersByTime(1980)
     })
     expect(screen.getByText('共感度を測定中...')).toBeInTheDocument()
+  })
+
+  it('最後のフレーズに到達したらそのまま表示を維持する', () => {
+    render(<JudgingIndicator />)
+
+    act(() => {
+      vi.advanceTimersByTime(1980 * 3)
+    })
+    expect(screen.getByText('最終判定を集計中 💡')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(1980 * 2)
+    })
+    expect(screen.getByText('最終判定を集計中 💡')).toBeInTheDocument()
+  })
+
+  it('ライブリージョンとして審査中状態を通知できる', () => {
+    render(<JudgingIndicator />)
+
+    expect(screen.getByTestId('judging-screen')).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByLabelText('審査中')).toBeInTheDocument()
+  })
+
+  it('reduced motion が有効でもフレーズは即時に切り替わる', () => {
+    useReducedMotionMock.mockReturnValue(true)
+
+    render(<JudgingIndicator />)
+
+    act(() => {
+      vi.advanceTimersByTime(1980)
+    })
+
+    expect(screen.getByText('審査員が評価中...')).toBeInTheDocument()
   })
 })

--- a/frontend/src/features/judging/components/__tests__/JudgingIndicator.test.tsx
+++ b/frontend/src/features/judging/components/__tests__/JudgingIndicator.test.tsx
@@ -70,7 +70,7 @@ describe('JudgingIndicator', () => {
     render(<JudgingIndicator />)
 
     expect(screen.getByTestId('judging-screen')).toHaveAttribute('aria-live', 'polite')
-    expect(screen.getByLabelText('審査中')).toBeInTheDocument()
+    expect(screen.getByRole('status', { name: '審査中' })).toBeInTheDocument()
   })
 
   it('reduced motion が有効でもフレーズは即時に切り替わる', () => {

--- a/frontend/src/features/judging/components/__tests__/JudgingIndicator.test.tsx
+++ b/frontend/src/features/judging/components/__tests__/JudgingIndicator.test.tsx
@@ -66,6 +66,23 @@ describe('JudgingIndicator', () => {
     expect(screen.getByText('最終判定を集計中 💡')).toBeInTheDocument()
   })
 
+  it('最後のフレーズ到達後は追加のタイマーを消費しない', () => {
+    render(<JudgingIndicator />)
+
+    act(() => {
+      vi.advanceTimersByTime(1980 * 3)
+    })
+
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => {
+      vi.advanceTimersByTime(1980)
+    })
+
+    expect(vi.getTimerCount()).toBe(0)
+    expect(screen.getByText('最終判定を集計中 💡')).toBeInTheDocument()
+  })
+
   it('ライブリージョンとして審査中状態を通知できる', () => {
     render(<JudgingIndicator />)
 

--- a/frontend/src/features/top/__tests__/MyPostStorage.refactor.test.tsx
+++ b/frontend/src/features/top/__tests__/MyPostStorage.refactor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from '../../../App'
 import { openMyPostsDialog } from '../../../test/appTestHelpers'
@@ -20,7 +20,9 @@ describe('MyPostStorage Refactor', () => {
 
     await openMyPostsDialog()
 
-    expect((await screen.findAllByTestId('my-post-id-item')).length).toBe(2)
-    expect(screen.getAllByRole('button', { name: 'id-1' })).toHaveLength(1)
+    const postItems = await screen.findAllByTestId('my-post-id-item')
+
+    expect(postItems).toHaveLength(2)
+    expect(postItems.filter((item) => within(item).queryByText('id-1'))).toHaveLength(1)
   })
 })

--- a/frontend/src/features/top/__tests__/myPostHighlight.integration.red.test.tsx
+++ b/frontend/src/features/top/__tests__/myPostHighlight.integration.red.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from '../../../App'
 import { api } from '../../../shared/services/api'
-import { mockRankings, openMyPostsDialog } from '../../../test/appTestHelpers'
+import { mockRankings, openMyPostsDialog, selectMyPost } from '../../../test/appTestHelpers'
 
 vi.mock('@tanstack/react-query-devtools', () => ({
   ReactQueryDevtools: () => <div data-testid="react-query-devtools" />,
@@ -49,9 +49,7 @@ describe('MyPostHighlight Integration RED', () => {
 
     render(<App />)
 
-    await openMyPostsDialog()
-    const idButton = await screen.findByRole('button', { name: 'id-1' })
-    fireEvent.click(idButton)
+    const idButton = await selectMyPost('id-1')
     fireEvent.click(idButton)
 
     await waitFor(() => expect(getPostSpy).toHaveBeenCalledTimes(1))

--- a/frontend/src/shared/services/analytics.test.ts
+++ b/frontend/src/shared/services/analytics.test.ts
@@ -23,9 +23,20 @@ describe('analytics', () => {
       delete window.gtag
     }
 
-    window.dataLayer = originalDataLayer ?? []
+    if (originalDataLayer) {
+      window.dataLayer = originalDataLayer
+    } else {
+      delete (window as { dataLayer?: unknown[] }).dataLayer
+    }
     document.title = originalTitle
     document.head.querySelector('#ga4-script')?.remove()
+  })
+
+  it.each([null, undefined])('計測IDが%sの場合はGA4スクリプトを初期化しない', (measurementId) => {
+    initializeGoogleAnalytics(measurementId)
+
+    expect(document.head.querySelector('#ga4-script')).toBeNull()
+    expect(window.dataLayer).toEqual([])
   })
 
   it('計測IDがある場合はGA4スクリプトと設定を初期化する', () => {

--- a/scripts/regenerate_all_ogps.rb
+++ b/scripts/regenerate_all_ogps.rb
@@ -14,7 +14,7 @@ logger.info "対象件数: #{scored_posts.size}件"
 scored_posts.each do |post|
   logger.info "処理開始: post_id=#{post.id}"
 
-  if UploadOgpImageService.call(post.id)
+  if UploadOgpImageService.call(post)
     logger.info "処理成功: post_id=#{post.id}"
   else
     logger.error "処理失敗: post_id=#{post.id}"


### PR DESCRIPTION
## 概要
- CodeRabbitの指摘に合わせて投稿一覧テストの要素特定を厳密化
- デモ投稿初期化タスクに確認プロンプトと空配列ガードを追加
- EP39-01の関連差分をまとめて反映

## 検証
- npm test -- --run src/features/top/__tests__/MyPostStorage.refactor.test.tsx
- bundle exec brakeman -q
- bundle exec rubocop -A --cache-root tmp/rubocop_cache （既存違反で失敗）
- bundle exec rspec （実行継続中のため完了未確認）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3優先のOGP画像選択、デモ投稿の固定シードデータとリセット機能（リセット用タスク含む）

* **Improvements**
  * 判定失敗時に結果画面へ即遷移
  * 判定表示のアクセシビリティ向上と低モーション対応
  * CLOUDFRONT未設定時の警告ログ強化
  * OGP画像存在キャッシュの更新・無効化による反映改善
  * テスト時のDynamoDBエンドポイント正規化導入

* **Tests**
  * S3/OGP、デモデータ、判定UIなどのテスト拡充（キャッシュ、例外、ARIA、ログ確認等）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->