### PR TITLE
fix: E39-01 投稿失敗時の仮ID遷移を修正 #01

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -973,8 +973,9 @@ function App() {
       sound.playSe(SOUND_SE_SUBMIT)
       setIsPostModalOpen(false)
       enterJudgingMode(temporaryPostId, false)
+      syncJudgingPath(temporaryPostId)
     },
-    [beginMinimumJudgingDuration, enterJudgingMode, sound]
+    [beginMinimumJudgingDuration, enterJudgingMode, sound, syncJudgingPath]
   )
 
   const applyJudgingSubmitSuccess = useCallback(
@@ -1432,25 +1433,7 @@ function App() {
         clearMyPostDetailError(postId)
         return response
       } catch (error) {
-        if (getErrorStatus(error) === HTTP_STATUS.NOT_FOUND) {
-          removePostId(postId)
-          setMyPostDetails((prev) => {
-            if (!(postId in prev)) return prev
-
-            const next = { ...prev }
-            delete next[postId]
-            myPostDetailsRef.current = next
-            return next
-          })
-          setMyPostDetailErrors((prev) => {
-            if (!(postId in prev)) return prev
-
-            const next = { ...prev }
-            delete next[postId]
-            return next
-          })
-          syncMyPostIds()
-        } else {
+        if (getErrorStatus(error) !== HTTP_STATUS.NOT_FOUND) {
           setMyPostDetailErrors((prev) => ({
             ...prev,
             [postId]: MESSAGE_MY_POST_DETAIL_FETCH_FAILED,
@@ -1462,7 +1445,7 @@ function App() {
         inFlightPostIdsRef.current.delete(postId)
       }
     },
-    [clearMyPostDetailError, setMyPostLoading, storeMyPostDetail, syncMyPostIds]
+    [clearMyPostDetailError, setMyPostLoading, storeMyPostDetail]
   )
 
   const prefetchMyPostsDetails = useCallback(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -973,9 +973,8 @@ function App() {
       sound.playSe(SOUND_SE_SUBMIT)
       setIsPostModalOpen(false)
       enterJudgingMode(temporaryPostId, false)
-      syncJudgingPath(temporaryPostId)
     },
-    [beginMinimumJudgingDuration, enterJudgingMode, sound, syncJudgingPath]
+    [beginMinimumJudgingDuration, enterJudgingMode, sound]
   )
 
   const applyJudgingSubmitSuccess = useCallback(
@@ -1433,7 +1432,25 @@ function App() {
         clearMyPostDetailError(postId)
         return response
       } catch (error) {
-        if (getErrorStatus(error) !== HTTP_STATUS.NOT_FOUND) {
+        if (getErrorStatus(error) === HTTP_STATUS.NOT_FOUND) {
+          removePostId(postId)
+          setMyPostDetails((prev) => {
+            if (!(postId in prev)) return prev
+
+            const next = { ...prev }
+            delete next[postId]
+            myPostDetailsRef.current = next
+            return next
+          })
+          setMyPostDetailErrors((prev) => {
+            if (!(postId in prev)) return prev
+
+            const next = { ...prev }
+            delete next[postId]
+            return next
+          })
+          syncMyPostIds()
+        } else {
           setMyPostDetailErrors((prev) => ({
             ...prev,
             [postId]: MESSAGE_MY_POST_DETAIL_FETCH_FAILED,
@@ -1445,7 +1462,7 @@ function App() {
         inFlightPostIdsRef.current.delete(postId)
       }
     },
-    [clearMyPostDetailError, setMyPostLoading, storeMyPostDetail]
+    [clearMyPostDetailError, setMyPostLoading, storeMyPostDetail, syncMyPostIds]
   )
 
   const prefetchMyPostsDetails = useCallback(

--- a/frontend/src/__tests__/App.optimisticSubmit.test.tsx
+++ b/frontend/src/__tests__/App.optimisticSubmit.test.tsx
@@ -71,10 +71,9 @@ describe('E12-XX RED: 楽観的投稿UI', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('judging-screen')).toBeInTheDocument()
-      expect(pushStateSpy).toHaveBeenCalledTimes(2)
+      expect(pushStateSpy).toHaveBeenCalledTimes(1)
     })
-    expect(pushStateSpy).toHaveBeenNthCalledWith(1, {}, '', `/judging/${tempPostId}`)
-    expect(pushStateSpy).toHaveBeenNthCalledWith(2, {}, '', '/judging/official-post-id')
+    expect(pushStateSpy).toHaveBeenNthCalledWith(1, {}, '', '/judging/official-post-id')
   })
 
   it('API失敗時は審査中画面に再投稿導線を出し、入力値を復元する', async () => {

--- a/frontend/src/__tests__/App.optimisticSubmit.test.tsx
+++ b/frontend/src/__tests__/App.optimisticSubmit.test.tsx
@@ -71,9 +71,15 @@ describe('E12-XX RED: 楽観的投稿UI', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('judging-screen')).toBeInTheDocument()
-      expect(pushStateSpy).toHaveBeenCalledTimes(1)
     })
-    expect(pushStateSpy).toHaveBeenNthCalledWith(1, {}, '', '/judging/official-post-id')
+    expect(
+      pushStateSpy.mock.calls.some((call) => call.some((arg) => arg === `/judging/${tempPostId}`))
+    ).toBe(false)
+    expect(
+      pushStateSpy.mock.calls.some((call) =>
+        call.some((arg) => arg === '/judging/official-post-id')
+      )
+    ).toBe(true)
   })
 
   it('API失敗時は審査中画面に再投稿導線を出し、入力値を復元する', async () => {

--- a/frontend/src/features/top/__tests__/myPostDetail.integration.red.test.tsx
+++ b/frontend/src/features/top/__tests__/myPostDetail.integration.red.test.tsx
@@ -186,4 +186,19 @@ describe('E16-01 MyPostDetail Integration RED', () => {
     await waitFor(() => expect(maxInFlight).toBeGreaterThan(0))
     await waitFor(() => expect(maxInFlight).toBeLessThanOrEqual(3))
   })
+
+  it('一覧事前取得で404になった投稿IDはローカル保存から除外する', async () => {
+    const stalePostId = '66666666-6666-4666-8666-666666666666'
+    vi.spyOn(api.posts, 'get').mockRejectedValue(new ApiClientError('not found', 'NOT_FOUND', 404))
+    localStorage.setItem('my_post_ids', JSON.stringify([stalePostId]))
+
+    render(<App />)
+
+    await openMyPostsDialog()
+
+    await waitFor(() => {
+      expect(localStorage.getItem('my_post_ids')).toBe(JSON.stringify([]))
+    })
+    expect(screen.getByText('投稿するとここに表示されます')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/features/top/__tests__/myPostDetail.integration.red.test.tsx
+++ b/frontend/src/features/top/__tests__/myPostDetail.integration.red.test.tsx
@@ -198,7 +198,7 @@ describe('E16-01 MyPostDetail Integration RED', () => {
 
     await waitFor(() => {
       expect(localStorage.getItem('my_post_ids')).toBe(JSON.stringify([]))
+      expect(screen.getByText('投稿するとここに表示されます')).toBeInTheDocument()
     })
-    expect(screen.getByText('投稿するとここに表示されます')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## 概要
- 投稿確定前の仮UUIDを `/judging/:id` に反映しないよう修正
- `自分の投稿` の事前取得で404になった投稿IDをローカル保存から除去
- 関連テストを更新

## 原因
- CloudWatch Logs上で 2026-03-14 18:58 JST 前後に `POST /api/posts` は到達しておらず、フロント側で送信前/送信途中に止まっていました
- 同日 16:17-16:22 JST に存在しない投稿IDへの `GET /api/posts/:id` が大量に404になっており、仮UUIDや古いIDの保持が原因と判断しました

## 確認
- `npm test -- --run src/__tests__/App.optimisticSubmit.test.tsx src/features/top/__tests__/myPostDetail.integration.red.test.tsx`
- `npx eslint src/App.tsx src/__tests__/App.optimisticSubmit.test.tsx src/features/top/__tests__/myPostDetail.integration.red.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 取得時に存在しない投稿（404）が検出された場合、マイ投稿一覧と画面表示から自動的に削除されるようになりました。

* **機能改善**
  * 投稿送信時の遷移挙動を調整し、一時的な仮投稿パスへの即時遷移が行われなくなりました。
  * 投稿詳細の状態管理と同期処理が強化され、表示の一貫性が向上しました。

* **テスト**
  * 404検出時の削除フローと最適化遷移を検証する統合・ユニットテストを追加／更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->