### PR TITLE
fix: EP41-01 OGP不具合と共有条件を調整 #01

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 imagemagick && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 imagemagick fonts-droid-fallback fonts-dejavu-core && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment

--- a/backend/app/services/ogp_generator_service.rb
+++ b/backend/app/services/ogp_generator_service.rb
@@ -11,10 +11,9 @@ class OgpGeneratorService
   BODY_LINE_SPACING = 14
 
   BASE_IMAGE_PATH = Rails.root.join('app/assets/images/base_ogp.png')
-  # ImageMagick 6系では OTF よりも TTF の方が日本語描画が安定する。
-  FONT_PATH = Pathname.new('/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf')
-  FONT_BOLD_PATH = Pathname.new('/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf')
-  NUMBER_FONT_PATH = Pathname.new('/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf')
+  FONT_PATH = Rails.root.join('app/assets/fonts/NotoSansJP-Regular.otf')
+  FONT_BOLD_PATH = Rails.root.join('app/assets/fonts/NotoSansJP-Bold.otf')
+  NUMBER_FONT_PATH = Rails.root.join('app/assets/fonts/NotoSansJP-Bold.otf')
   REQUIRED_FILES = [BASE_IMAGE_PATH, FONT_PATH, FONT_BOLD_PATH, NUMBER_FONT_PATH].freeze
 
   # 画像レイアウト定数

--- a/backend/app/services/ogp_generator_service.rb
+++ b/backend/app/services/ogp_generator_service.rb
@@ -11,11 +11,11 @@ class OgpGeneratorService
   BODY_LINE_SPACING = 14
 
   BASE_IMAGE_PATH = Rails.root.join('app/assets/images/base_ogp.png')
-  # 実行環境依存のシステムフォントではなく、同梱フォントを使って描画失敗を防ぐ。
-  FONT_PATH = Rails.root.join('app/assets/fonts/NotoSansJP-Regular.otf')
-  FONT_BOLD_PATH = Rails.root.join('app/assets/fonts/NotoSansJP-Bold.otf')
-  NUMBER_FONT_PATH = Rails.root.join('app/assets/fonts/NotoSansJP-Bold.otf')
-  REQUIRED_FILES = [BASE_IMAGE_PATH, FONT_PATH, FONT_BOLD_PATH, NUMBER_FONT_PATH].uniq.freeze
+  # ImageMagick 6系では OTF よりも TTF の方が日本語描画が安定する。
+  FONT_PATH = Pathname.new('/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf')
+  FONT_BOLD_PATH = Pathname.new('/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf')
+  NUMBER_FONT_PATH = Pathname.new('/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf')
+  REQUIRED_FILES = [BASE_IMAGE_PATH, FONT_PATH, FONT_BOLD_PATH, NUMBER_FONT_PATH].freeze
 
   # 画像レイアウト定数
   LAYOUT = {

--- a/backend/app/services/ogp_meta_tag_service.rb
+++ b/backend/app/services/ogp_meta_tag_service.rb
@@ -186,8 +186,6 @@ class OgpMetaTagService
   end
 
   def self.uploaded_image_exists_cache_store
-    return Rails.cache unless Rails.cache.is_a?(ActiveSupport::Cache::NullStore)
-
     @uploaded_image_exists_cache_store ||= ActiveSupport::Cache::MemoryStore.new
   end
 

--- a/backend/spec/services/ogp_generator_service_spec.rb
+++ b/backend/spec/services/ogp_generator_service_spec.rb
@@ -40,13 +40,19 @@ RSpec.describe OgpGeneratorService, dynamodb: false do
       expect(described_class::FONT_SIZES.keys).not_to include(:judge_score, :judge_comment)
     end
 
-    it '同梱フォントを使用すること' do
-      expect(described_class::FONT_PATH).to eq(Rails.root.join('app/assets/fonts/NotoSansJP-Regular.otf'))
-      expect(described_class::FONT_BOLD_PATH).to eq(Rails.root.join('app/assets/fonts/NotoSansJP-Bold.otf'))
-      expect(described_class::NUMBER_FONT_PATH).to eq(Rails.root.join('app/assets/fonts/NotoSansJP-Bold.otf'))
+    it '日本語描画が安定するTTFフォントを使用すること' do
+      expect(described_class::FONT_PATH).to eq(
+        Pathname.new('/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf')
+      )
+      expect(described_class::FONT_BOLD_PATH).to eq(
+        Pathname.new('/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf')
+      )
+      expect(described_class::NUMBER_FONT_PATH).to eq(
+        Pathname.new('/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf')
+      )
     end
 
-    it '同梱フォント実体が存在すること' do
+    it '描画に使用するフォント実体が存在すること' do
       expect(described_class::FONT_PATH.exist?).to be(true)
       expect(described_class::FONT_BOLD_PATH.exist?).to be(true)
       expect(described_class::NUMBER_FONT_PATH.exist?).to be(true)

--- a/backend/spec/services/ogp_generator_service_spec.rb
+++ b/backend/spec/services/ogp_generator_service_spec.rb
@@ -40,15 +40,15 @@ RSpec.describe OgpGeneratorService, dynamodb: false do
       expect(described_class::FONT_SIZES.keys).not_to include(:judge_score, :judge_comment)
     end
 
-    it '日本語描画が安定するTTFフォントを使用すること' do
+    it 'アプリ同梱のフォントを使用すること' do
       expect(described_class::FONT_PATH).to eq(
-        Pathname.new('/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf')
+        Rails.root.join('app/assets/fonts/NotoSansJP-Regular.otf')
       )
       expect(described_class::FONT_BOLD_PATH).to eq(
-        Pathname.new('/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf')
+        Rails.root.join('app/assets/fonts/NotoSansJP-Bold.otf')
       )
       expect(described_class::NUMBER_FONT_PATH).to eq(
-        Pathname.new('/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf')
+        Rails.root.join('app/assets/fonts/NotoSansJP-Bold.otf')
       )
     end
 

--- a/backend/spec/services/ogp_meta_tag_service_spec.rb
+++ b/backend/spec/services/ogp_meta_tag_service_spec.rb
@@ -340,6 +340,19 @@ RSpec.describe OgpMetaTagService, type: :service do
         expect(head_requests.size).to eq(1)
       end
 
+      it 'Rails.cache が書き込み不可でも MemoryStore で画像存在確認をキャッシュできること' do
+        ENV['OGP_S3_BUCKET'] = 'test-ogp-bucket'
+        s3_client = Aws::S3::Client.new(region: 'ap-northeast-1', stub_responses: true)
+        allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
+        allow(Rails).to receive(:cache).and_raise(Errno::EROFS)
+
+        2.times { described_class.generate_html(post:, base_url:) }
+
+        head_requests = s3_client.api_requests.select { |request| request[:operation_name] == :head_object }
+
+        expect(head_requests.size).to eq(1)
+      end
+
       it 'S3に画像が存在しない場合はfalseをキャッシュしないこと' do
         ENV['OGP_S3_BUCKET'] = 'test-ogp-bucket'
         s3_client = Aws::S3::Client.new(region: 'ap-northeast-1', stub_responses: true)

--- a/backend/spec/terraform/iam_spec.rb
+++ b/backend/spec/terraform/iam_spec.rb
@@ -4,20 +4,21 @@ require 'rails_helper'
 
 RSpec.describe 'Terraform IAM設定' do
   let(:iam_tf_content) { Rails.root.join('terraform/iam.tf').read }
+  let(:s3_ogp_access_block) do
+    iam_tf_content.match(
+      /resource\s+"aws_iam_role_policy"\s+"s3_ogp_access"\s+\{.*?^\}/m
+    )&.[](0)
+  end
 
   describe 'OGP用S3権限' do
-    it 'OGP画像の存在確認に必要な s3:GetObject が許可されていること' do
-      expect(iam_tf_content).to match(/resource\s+"aws_iam_role_policy"\s+"s3_ogp_access"/)
-      expect(iam_tf_content).to match(/s3:GetObject/)
+    it 's3_ogp_access ポリシーが定義されていること' do
+      expect(s3_ogp_access_block).not_to be_nil
     end
 
-    it 'OGP画像のアップロードに必要な s3:PutObject が許可されていること' do
-      expect(iam_tf_content).to match(/resource\s+"aws_iam_role_policy"\s+"s3_ogp_access"/)
-      expect(iam_tf_content).to match(/s3:PutObject/)
-    end
-
-    it 'OGP画像プレフィックスのみに権限が絞られていること' do
-      expect(iam_tf_content).to match(%r{arn:aws:s3:::\$\{var\.frontend_s3_bucket_name\}/ogp/\*})
+    it 's3_ogp_access ポリシー内に必要な権限が含まれていること' do
+      expect(s3_ogp_access_block).to match(/s3:GetObject/)
+      expect(s3_ogp_access_block).to match(/s3:PutObject/)
+      expect(s3_ogp_access_block).to match(%r{arn:aws:s3:::\$\{var\.frontend_s3_bucket_name\}/ogp/\*})
     end
   end
 end

--- a/backend/spec/terraform/iam_spec.rb
+++ b/backend/spec/terraform/iam_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Terraform IAM設定' do
+  let(:iam_tf_content) { Rails.root.join('terraform/iam.tf').read }
+
+  describe 'OGP用S3権限' do
+    it 'OGP画像の存在確認に必要な s3:GetObject が許可されていること' do
+      expect(iam_tf_content).to match(/resource\s+"aws_iam_role_policy"\s+"s3_ogp_access"/)
+      expect(iam_tf_content).to match(/s3:GetObject/)
+    end
+
+    it 'OGP画像のアップロードに必要な s3:PutObject が許可されていること' do
+      expect(iam_tf_content).to match(/resource\s+"aws_iam_role_policy"\s+"s3_ogp_access"/)
+      expect(iam_tf_content).to match(/s3:PutObject/)
+    end
+
+    it 'OGP画像プレフィックスのみに権限が絞られていること' do
+      expect(iam_tf_content).to match(%r{arn:aws:s3:::\$\{var\.frontend_s3_bucket_name\}/ogp/\*})
+    end
+  end
+end

--- a/backend/terraform/iam.tf
+++ b/backend/terraform/iam.tf
@@ -94,6 +94,7 @@ resource "aws_iam_role_policy" "s3_ogp_access" {
       {
         Effect = "Allow"
         Action = [
+          "s3:GetObject",
           "s3:PutObject"
         ]
         Resource = "arn:aws:s3:::${var.frontend_s3_bucket_name}/ogp/*"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -102,6 +102,7 @@ const LOW_SCORE_THRESHOLD = SCORE_THRESHOLDS.LOW
 const CONTACT_FORM_URL = 'https://forms.gle/zLN3j3YF87qdULXB9'
 const FIXED_FOOTER_MIN_RESERVED_PX = 96
 const FIXED_FOOTER_EXTRA_GAP_PX = 12
+const SHAREABLE_RESULT_MAX_RANK = 20
 const POST_SHARE_PATH_PREFIX = '/posts/'
 const OGP_IMAGE_PATH_PREFIX = '/ogp/posts/'
 const X_SHARE_INTENT_URL = 'https://twitter.com/intent/tweet'
@@ -138,6 +139,15 @@ function isFinalResultPost(post: Post | null): post is Post & { status: 'scored'
   return post !== null && (post.status === 'scored' || post.status === 'failed')
 }
 
+function hasShareableRank(rank: number | undefined): rank is number {
+  return (
+    typeof rank === 'number' &&
+    Number.isInteger(rank) &&
+    rank >= 1 &&
+    rank <= SHAREABLE_RESULT_MAX_RANK
+  )
+}
+
 function readFrontendBaseUrl(): string {
   const envBaseUrl = import.meta.env.VITE_FRONTEND_BASE_URL?.trim()
   return envBaseUrl && envBaseUrl.length > 0 ? envBaseUrl : window.location.origin
@@ -158,10 +168,7 @@ function buildOgpPreviewUrl(postId: string): string {
 
 function buildResultShareText(post: Post): string {
   const scoreLabel = typeof post.average_score === 'number' ? post.average_score.toFixed(1) : '--.-'
-  const rankLabel =
-    typeof post.rank === 'number' && Number.isInteger(post.rank) && post.rank >= 1
-      ? `${post.rank}位`
-      : '結果発表'
+  const rankLabel = hasShareableRank(post.rank) ? `${post.rank}位` : 'ランクイン'
   return `「${post.body}」\n${post.nickname}さんのあるあるは ${rankLabel} / ${scoreLabel}点！\n#あるあるアリーナ`
 }
 
@@ -177,7 +184,12 @@ function canShowPostJudgingShareActions(
   post: Post | null,
   source: ResultViewSource
 ): post is Post & { status: 'scored' } {
-  return source === 'judging' && isFinalResultPost(post) && post.status === 'scored'
+  return (
+    source === 'judging' &&
+    isFinalResultPost(post) &&
+    post.status === 'scored' &&
+    hasShareableRank(post.rank)
+  )
 }
 
 function isHighScoreResult(post: Post | null): post is Post & { status: 'scored'; average_score: number } {

--- a/frontend/src/features/result/__tests__/ResultModalFlow.red.test.tsx
+++ b/frontend/src/features/result/__tests__/ResultModalFlow.red.test.tsx
@@ -357,8 +357,8 @@ describe('E15-01 RED: ResultModal Flow', () => {
     })
   }, 12000)
 
-  it('TOP20圏外のscored投稿でも審査直後ならシェア関連UIを表示する', async () => {
-    // 何を検証するか: 審査直後の結果ではrankが21位以降でも共有UIを表示すること
+  it('TOP20圏外のscored投稿ではシェア関連UIを表示しない', async () => {
+    // 何を検証するか: 審査直後でも rank が 21 位以降なら共有UIを表示しないこと
     vi.spyOn(api.posts, 'create').mockResolvedValue({
       id: 'scope-post-id',
       status: 'judging',
@@ -386,12 +386,8 @@ describe('E15-01 RED: ResultModal Flow', () => {
       { timeout: 9000 }
     )
 
-    expect(screen.getByRole('button', { name: 'Xでシェア' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'シェア画像を表示' })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Xでシェア' }))
-    const lastOpenCallIndex = vi.mocked(window.open).mock.calls.length - 1
-    const [shareIntentUrl] = vi.mocked(window.open).mock.calls[lastOpenCallIndex] as [string]
-    expect(decodeURIComponent(shareIntentUrl)).toContain('21位')
+    expect(screen.queryByRole('button', { name: 'Xでシェア' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'シェア画像を表示' })).not.toBeInTheDocument()
     expect(screen.queryByTestId('ogp-preview')).not.toBeInTheDocument()
   }, 12000)
 


### PR DESCRIPTION
## 概要
- OGP生成とメタタグ判定の不具合を修正
- Terraform IAM の検証 spec を追加
- X共有条件と関連テストを調整

## 検証
- bundle exec rspec spec/services/ogp_generator_service_spec.rb spec/services/ogp_meta_tag_service_spec.rb spec/terraform/iam_spec.rb
- npx vitest run src/features/result/__tests__/ResultModalFlow.red.test.tsx --pool=threads

## 補足
- RSpec は 136 examples, 0 failures
- 終了コードは SimpleCov の全体カバレッジ閾値で 2 になっています

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 結果シェア機能を上位20ランク以内に制限しました（TOP20のみ共有可能）。

* **Bug Fixes**
  * キャッシュ処理を強化し、ストレージ書き込み障害時でもメモリキャッシュを利用して外部リクエストを削減するようにしました。
  * フォント関連の表示安定性を向上させる調整を行いました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->